### PR TITLE
Add timer callbacks for gameobjects functions

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     mesh.cpp
     pong.cpp
     rectangle.cpp
+    timer.cpp
 )
 
 add_library(engine ${SOURCES})

--- a/engine/pong.cpp
+++ b/engine/pong.cpp
@@ -91,9 +91,9 @@ void Pong::Cleanup()
     GetInstance().mGameObjects.clear();
 }
 
-void Pong::SetTimeout(int gameObjectId, int timeoutMs, std::function<void()> callback)
+void Pong::SetTimeout(int gameObjectId, std::chrono::duration<double> timeout, std::function<void()> callback)
 {
-    GetInstance().mTimer.AddTimer(gameObjectId, timeoutMs, callback);
+    GetInstance().mTimer.AddTimer(gameObjectId, timeout, callback);
 }
 
 } // namespace pong

--- a/engine/pong.cpp
+++ b/engine/pong.cpp
@@ -17,6 +17,16 @@ Pong& Pong::GetInstance()
     return instance;
 }
 
+CollisionManager& Pong::GetCollisionManager()
+{
+    return mCollisionManager;
+}
+
+Timer& Pong::GetTimer()
+{
+    return mTimer;
+}
+
 void Pong::Init()
 {
     auto player = std::make_unique<Player>();
@@ -62,8 +72,8 @@ void Pong::Init()
 
 void Pong::GameLoop()
 {
-    GetInstance().mTimer.HandleTimerCallbacks();
-    GetInstance().mCollisionManager.ProcessCollisions(GetInstance().mGameObjects);
+    Pong::GetInstance().GetTimer().HandleTimerCallbacks();
+    Pong::GetInstance().GetCollisionManager().ProcessCollisions(GetInstance().mGameObjects);
 
     for (auto& gameObject : GetInstance().mGameObjects)
     {

--- a/engine/pong.cpp
+++ b/engine/pong.cpp
@@ -62,8 +62,8 @@ void Pong::Init()
 
 void Pong::GameLoop()
 {
-    GetInstance().mCollisionManager.ProcessCollisions(GetInstance().mGameObjects);
     GetInstance().mTimer.HandleTimerCallbacks();
+    GetInstance().mCollisionManager.ProcessCollisions(GetInstance().mGameObjects);
 
     for (auto& gameObject : GetInstance().mGameObjects)
     {

--- a/engine/pong.cpp
+++ b/engine/pong.cpp
@@ -62,12 +62,13 @@ void Pong::Init()
 
 void Pong::GameLoop()
 {
+    GetInstance().mCollisionManager.ProcessCollisions(GetInstance().mGameObjects);
+    GetInstance().mTimer.HandleTimerCallbacks();
+
     for (auto& gameObject : GetInstance().mGameObjects)
     {
         gameObject->OnUpdate();
     }
-
-    GetInstance().mCollisionManager.ProcessCollisions(GetInstance().mGameObjects);
 
     for (auto& gameObject : GetInstance().mGameObjects)
     {
@@ -78,6 +79,11 @@ void Pong::GameLoop()
 void Pong::Cleanup()
 {
     GetInstance().mGameObjects.clear();
+}
+
+void Pong::SetTimeout(int gameObjectId, int timeoutMs, std::function<void()> callback)
+{
+    GetInstance().mTimer.AddTimer(gameObjectId, timeoutMs, callback);
 }
 
 } // namespace pong

--- a/engine/pong.h
+++ b/engine/pong.h
@@ -2,10 +2,12 @@
 
 #include "collisionmanager.h"
 #include "gameobject.h"
+#include "timer.h"
 #include "utils.h"
 
 #include <memory>
 #include <vector>
+#include <functional>
 
 namespace pong
 {
@@ -22,6 +24,7 @@ private:
 
     std::vector<std::unique_ptr<GameObject>>mGameObjects {};
     CollisionManager mCollisionManager {};
+    Timer mTimer {};
 
 public:
     static Pong& GetInstance();
@@ -43,6 +46,8 @@ public:
         }
         return nullptr;
     }
+
+    static void SetTimeout(int gameObjectId, int timeoutMs, std::function<void()> callback);
 };
 
 } // namespace pong

--- a/engine/pong.h
+++ b/engine/pong.h
@@ -5,6 +5,7 @@
 #include "timer.h"
 #include "utils.h"
 
+#include <chrono>
 #include <memory>
 #include <vector>
 #include <functional>
@@ -51,7 +52,7 @@ public:
         return nullptr;
     }
 
-    static void SetTimeout(int gameObjectId, int timeoutMs, std::function<void()> callback);
+    static void SetTimeout(int gameObjectId, std::chrono::duration<double> timeout, std::function<void()> callback);
 };
 
 } // namespace pong

--- a/engine/pong.h
+++ b/engine/pong.h
@@ -22,6 +22,9 @@ private:
     Pong& operator=(Pong&&) = delete;
     ~Pong() = default;
 
+    CollisionManager& GetCollisionManager();
+    Timer& GetTimer();
+
     std::vector<std::unique_ptr<GameObject>>mGameObjects {};
     CollisionManager mCollisionManager {};
     Timer mTimer {};

--- a/engine/pong.h
+++ b/engine/pong.h
@@ -25,6 +25,7 @@ private:
     std::vector<std::unique_ptr<GameObject>>mGameObjects {};
     CollisionManager mCollisionManager {};
     Timer mTimer {};
+    bool mFirstFrame { true };
 
 public:
     static Pong& GetInstance();

--- a/engine/timer.cpp
+++ b/engine/timer.cpp
@@ -1,5 +1,7 @@
 #include "timer.h"
 
+#include <spdlog/spdlog.h>
+
 #include <algorithm>
 #include <chrono>
 #include <iostream>

--- a/engine/timer.cpp
+++ b/engine/timer.cpp
@@ -2,17 +2,23 @@
 
 #include <algorithm>
 #include <chrono>
+#include <iostream>
 #include <memory>
 
 namespace pong
 {
 
 static constexpr int MS_TO_US = 1000;
+static constexpr int S_TO_US = 1000000;
+
+float Timer::frameTime = 1.0f;
 
 void Timer::HandleTimerCallbacks()
 {
     const auto timeWaited = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - mLastTime);
     mLastTime = std::chrono::system_clock::now();
+
+    Timer::frameTime = static_cast<float>(timeWaited.count()) / static_cast<float>(S_TO_US);
 
     const int timeWaitedUs = static_cast<int>(timeWaited.count());
     for (auto& timerRequest : mActiveTimers)

--- a/engine/timer.cpp
+++ b/engine/timer.cpp
@@ -1,0 +1,42 @@
+#include "timer.h"
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+
+namespace pong
+{
+
+static constexpr int MS_TO_US = 1000;
+
+void Timer::HandleTimerCallbacks()
+{
+    const auto timeWaited = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - mLastTime);
+    mLastTime = std::chrono::system_clock::now();
+
+    const int timeWaitedUs = static_cast<int>(timeWaited.count());
+    for (auto& timerRequest : mActiveTimers)
+    {
+        timerRequest->mTimeoutUs -= timeWaitedUs;
+        if (timerRequest->mTimeoutUs <= 0)
+        {
+            timerRequest->mCallback();
+        }
+    }
+
+    mActiveTimers.erase(std::remove_if(mActiveTimers.begin(), mActiveTimers.end(), [](const auto& timerRequest) {
+        return timerRequest->mTimeoutUs <= 0;
+    }), mActiveTimers.end());
+}
+
+void Timer::AddTimer(int gameObjectId, int timeoutMs, std::function<void()> callback)
+{
+    // Interface uses ms but internally keeps track using us. This is just in case the
+    // game's framerate is uncapped. It is possible that {timeWaited} is less then 1ms
+    // and comes out to 0 then the timer will not proceed.
+    const int timeoutUs = timeoutMs * MS_TO_US;
+    auto timerRequest = std::make_shared<TimerRequest>(gameObjectId, timeoutUs, callback);
+    mActiveTimers.push_back(timerRequest);
+}
+
+} // namespace pong

--- a/engine/timer.cpp
+++ b/engine/timer.cpp
@@ -10,39 +10,35 @@
 namespace pong
 {
 
-static constexpr int MS_TO_US = 1000;
-static constexpr int S_TO_US = 1000000;
-
 float Timer::frameTime = 1.0f;
 
 void Timer::HandleTimerCallbacks()
 {
-    const auto timeWaited = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - mLastTime);
+    const auto timeWaitedUs = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - mLastTime);
     mLastTime = std::chrono::system_clock::now();
 
-    Timer::frameTime = static_cast<float>(timeWaited.count()) / static_cast<float>(S_TO_US);
+    Timer::frameTime = (std::chrono::duration_cast<std::chrono::duration<float>>(timeWaitedUs)).count();
 
-    const int timeWaitedUs = static_cast<int>(timeWaited.count());
     for (auto& timerRequest : mActiveTimers)
     {
         timerRequest.mTimeoutUs -= timeWaitedUs;
-        if (timerRequest.mTimeoutUs <= 0)
+        if (timerRequest.mTimeoutUs.count() <= 0)
         {
             timerRequest.mCallback();
         }
     }
 
     mActiveTimers.erase(std::remove_if(mActiveTimers.begin(), mActiveTimers.end(), [](const auto& timerRequest) {
-        return timerRequest.mTimeoutUs <= 0;
+        return timerRequest.mTimeoutUs.count() <= 0;
     }), mActiveTimers.end());
 }
 
-void Timer::AddTimer(int gameObjectId, int timeoutMs, std::function<void()> callback)
+void Timer::AddTimer(int gameObjectId, std::chrono::duration<double> timeout, std::function<void()> callback)
 {
-    // Interface uses ms but internally keeps track using us. This is just in case the
+    // Internally keeps track using us. This is just in case the
     // game's framerate is uncapped. If using ms, it is possible that {timeWaited} is less then 1ms
     // and comes out to 0. This will cause the timer to not proceed.
-    const int timeoutUs = timeoutMs * MS_TO_US;
+    const auto timeoutUs = std::chrono::duration_cast<std::chrono::microseconds>(timeout);
     mActiveTimers.emplace_back(gameObjectId, timeoutUs, callback);
 }
 

--- a/engine/timer.cpp
+++ b/engine/timer.cpp
@@ -25,26 +25,25 @@ void Timer::HandleTimerCallbacks()
     const int timeWaitedUs = static_cast<int>(timeWaited.count());
     for (auto& timerRequest : mActiveTimers)
     {
-        timerRequest->mTimeoutUs -= timeWaitedUs;
-        if (timerRequest->mTimeoutUs <= 0)
+        timerRequest.mTimeoutUs -= timeWaitedUs;
+        if (timerRequest.mTimeoutUs <= 0)
         {
-            timerRequest->mCallback();
+            timerRequest.mCallback();
         }
     }
 
     mActiveTimers.erase(std::remove_if(mActiveTimers.begin(), mActiveTimers.end(), [](const auto& timerRequest) {
-        return timerRequest->mTimeoutUs <= 0;
+        return timerRequest.mTimeoutUs <= 0;
     }), mActiveTimers.end());
 }
 
 void Timer::AddTimer(int gameObjectId, int timeoutMs, std::function<void()> callback)
 {
     // Interface uses ms but internally keeps track using us. This is just in case the
-    // game's framerate is uncapped. It is possible that {timeWaited} is less then 1ms
-    // and comes out to 0 then the timer will not proceed.
+    // game's framerate is uncapped. If using ms, it is possible that {timeWaited} is less then 1ms
+    // and comes out to 0. This will cause the timer to not proceed.
     const int timeoutUs = timeoutMs * MS_TO_US;
-    auto timerRequest = std::make_shared<TimerRequest>(gameObjectId, timeoutUs, callback);
-    mActiveTimers.push_back(timerRequest);
+    mActiveTimers.emplace_back(gameObjectId, timeoutUs, callback);
 }
 
 } // namespace pong

--- a/engine/timer.h
+++ b/engine/timer.h
@@ -9,10 +9,12 @@
 namespace pong
 {
 
+static constexpr int kInvalid = -1;
+
 struct TimerRequest
 {
-    int mGameObjectId { -1 };
-    int mTimeoutUs { -1 };
+    int mGameObjectId { kInvalid };
+    int mTimeoutUs { kInvalid };
     std::function<void()> mCallback {};
 
     TimerRequest(int gameObjectId, int timeoutUs, std::function<void()> callback)
@@ -26,7 +28,7 @@ struct TimerRequest
 class Timer
 {
 private:
-    std::vector<std::shared_ptr<TimerRequest>> mActiveTimers {};
+    std::vector<TimerRequest> mActiveTimers {};
     std::chrono::system_clock::time_point mLastTime { std::chrono::system_clock::now() };
 
 public:

--- a/engine/timer.h
+++ b/engine/timer.h
@@ -14,10 +14,10 @@ static constexpr int kInvalid = -1;
 struct TimerRequest
 {
     int mGameObjectId { kInvalid };
-    int mTimeoutUs { kInvalid };
+    std::chrono::microseconds mTimeoutUs { kInvalid };
     std::function<void()> mCallback {};
 
-    TimerRequest(int gameObjectId, int timeoutUs, std::function<void()> callback)
+    TimerRequest(int gameObjectId, std::chrono::microseconds timeoutUs, std::function<void()> callback)
         : mGameObjectId(gameObjectId),
           mTimeoutUs(timeoutUs),
           mCallback(callback)
@@ -34,7 +34,7 @@ private:
 public:
     static float frameTime;
 
-    void AddTimer(int gameObjectId, int timeoutMs, std::function<void()> callback);
+    void AddTimer(int gameObjectId, std::chrono::duration<double> timeout, std::function<void()> callback);
     void HandleTimerCallbacks();
 };
 

--- a/engine/timer.h
+++ b/engine/timer.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <queue>
+#include <vector>
+
+namespace pong
+{
+
+struct TimerRequest
+{
+    int mGameObjectId;
+    int mTimeoutUs;
+    std::function<void()> mCallback;
+
+    TimerRequest(int gameObjectId, int timeoutUs, std::function<void()> callback)
+        : mGameObjectId(gameObjectId),
+          mTimeoutUs(timeoutUs),
+          mCallback(callback)
+    {
+    }
+};
+
+class Timer
+{
+private:
+    std::vector<std::shared_ptr<TimerRequest>> mActiveTimers {};
+    std::chrono::system_clock::time_point mLastTime { std::chrono::system_clock::now() };
+
+public:
+    void AddTimer(int gameObjectId, int timeoutMs, std::function<void()> callback);
+    void HandleTimerCallbacks();
+};
+
+} // namespace pong

--- a/engine/timer.h
+++ b/engine/timer.h
@@ -11,9 +11,9 @@ namespace pong
 
 struct TimerRequest
 {
-    int mGameObjectId;
-    int mTimeoutUs;
-    std::function<void()> mCallback;
+    int mGameObjectId { -1 };
+    int mTimeoutUs { -1 };
+    std::function<void()> mCallback {};
 
     TimerRequest(int gameObjectId, int timeoutUs, std::function<void()> callback)
         : mGameObjectId(gameObjectId),
@@ -30,6 +30,8 @@ private:
     std::chrono::system_clock::time_point mLastTime { std::chrono::system_clock::now() };
 
 public:
+    static float frameTime;
+
     void AddTimer(int gameObjectId, int timeoutMs, std::function<void()> callback);
     void HandleTimerCallbacks();
 };

--- a/gameobjects/ball.cpp
+++ b/gameobjects/ball.cpp
@@ -2,7 +2,10 @@
 
 #include "opponent.h"
 #include "player.h"
+#include "pong.h"
 #include "rectangle.h"
+
+#include <spdlog/spdlog.h>
 
 #include <random>
 
@@ -36,7 +39,7 @@ void Ball::OnCollisionStart(GameObject& other)
 {
     if (other.GetInstanceName() == "ScoreArea")
     {
-        ResetBall();
+        Pong::SetTimeout(GetId(), 3000, std::bind(&Ball::ResetBall, this));
     }
     else if (other.GetInstanceName() == "Player" || other.GetInstanceName() == "Opponent")
     {

--- a/gameobjects/ball.cpp
+++ b/gameobjects/ball.cpp
@@ -41,7 +41,10 @@ void Ball::OnCollisionStart(GameObject& other)
 {
     if (other.GetInstanceName() == "ScoreArea")
     {
-        SetTimeout(BALL_RESET_WAIT_MS, std::bind(&Ball::ResetBall, this));
+        SetTimeout(BALL_RESET_WAIT_MS, [this] ()
+        {
+            this->ResetBall();
+        });
     }
     else if (other.GetInstanceName() == "Player" || other.GetInstanceName() == "Opponent")
     {

--- a/gameobjects/ball.cpp
+++ b/gameobjects/ball.cpp
@@ -4,6 +4,7 @@
 #include "player.h"
 #include "pong.h"
 #include "rectangle.h"
+#include "timer.h"
 
 #include <spdlog/spdlog.h>
 
@@ -13,7 +14,7 @@ namespace pong
 {
 
 static constexpr float BALL_WIDTH = 20.0f;
-static constexpr float BALL_SPEED_BOUNCE_INCREMENT = 0.5f;
+static constexpr float BALL_SPEED_BOUNCE_INCREMENT = 75.0f;
 static constexpr float Y_STARTING_POSITION_BOUNDS = 500.0f;
 
 std::random_device rd;
@@ -31,7 +32,7 @@ void Ball::OnStart()
 
 void Ball::OnUpdate()
 {
-    const glm::vec3 newPosition = GetPosition() + mVelocity;
+    const glm::vec3 newPosition = GetPosition() + mVelocity * Timer::frameTime;
     SetPosition(newPosition);
 }
 

--- a/gameobjects/ball.cpp
+++ b/gameobjects/ball.cpp
@@ -2,7 +2,6 @@
 
 #include "opponent.h"
 #include "player.h"
-#include "pong.h"
 #include "rectangle.h"
 #include "timer.h"
 
@@ -16,6 +15,8 @@ namespace pong
 static constexpr float BALL_WIDTH = 20.0f;
 static constexpr float BALL_SPEED_BOUNCE_INCREMENT = 75.0f;
 static constexpr float Y_STARTING_POSITION_BOUNDS = 500.0f;
+
+static constexpr int BALL_RESET_WAIT_MS = 3000;
 
 std::random_device rd;
 std::mt19937 generator(rd());
@@ -40,7 +41,7 @@ void Ball::OnCollisionStart(GameObject& other)
 {
     if (other.GetInstanceName() == "ScoreArea")
     {
-        Pong::SetTimeout(GetId(), 3000, std::bind(&Ball::ResetBall, this));
+        SetTimeout(BALL_RESET_WAIT_MS, std::bind(&Ball::ResetBall, this));
     }
     else if (other.GetInstanceName() == "Player" || other.GetInstanceName() == "Opponent")
     {

--- a/gameobjects/ball.cpp
+++ b/gameobjects/ball.cpp
@@ -16,7 +16,7 @@ static constexpr float BALL_WIDTH = 20.0f;
 static constexpr float BALL_SPEED_BOUNCE_INCREMENT = 75.0f;
 static constexpr float Y_STARTING_POSITION_BOUNDS = 500.0f;
 
-static constexpr int BALL_RESET_WAIT_MS = 3000;
+static constexpr std::chrono::seconds BALL_RESET_WAIT_S { 3 };
 
 std::random_device rd;
 std::mt19937 generator(rd());
@@ -41,7 +41,7 @@ void Ball::OnCollisionStart(GameObject& other)
 {
     if (other.GetInstanceName() == "ScoreArea")
     {
-        SetTimeout(BALL_RESET_WAIT_MS, [this] ()
+        SetTimeout(BALL_RESET_WAIT_S, [this] ()
         {
             this->ResetBall();
         });

--- a/gameobjects/ball.h
+++ b/gameobjects/ball.h
@@ -8,7 +8,7 @@ namespace pong
 class Ball : public GameObject
 {
 private:
-    static constexpr float BALL_START_SPEED = 7.5f;
+    static constexpr float BALL_START_SPEED = 1000.0f;
 
     glm::vec3 mVelocity { BALL_START_SPEED, BALL_START_SPEED, 0.0f };
     float mSpeed { BALL_START_SPEED };

--- a/gameobjects/gameobject.cpp
+++ b/gameobjects/gameobject.cpp
@@ -1,6 +1,7 @@
 #include "gameobject.h"
 
 #include "renderutils.h"
+#include "pong.h"
 
 namespace pong
 {
@@ -69,6 +70,11 @@ bool GameObject::CheckForCollision(GameObject& other)
         return mColliderBox->CheckForCollision(*other.mColliderBox);
     }
     return false;
+}
+
+void GameObject::SetTimeout(int timeoutMs, std::function<void()> callback)
+{
+    Pong::SetTimeout(GetId(), timeoutMs, callback);
 }
 
 void GameObject::Render() const

--- a/gameobjects/gameobject.cpp
+++ b/gameobjects/gameobject.cpp
@@ -72,9 +72,9 @@ bool GameObject::CheckForCollision(GameObject& other)
     return false;
 }
 
-void GameObject::SetTimeout(int timeoutMs, std::function<void()> callback)
+void GameObject::SetTimeout(std::chrono::duration<double> timeout, std::function<void()> callback)
 {
-    Pong::SetTimeout(GetId(), timeoutMs, callback);
+    Pong::SetTimeout(GetId(), timeout, callback);
 }
 
 void GameObject::Render() const

--- a/gameobjects/gameobject.h
+++ b/gameobjects/gameobject.h
@@ -6,6 +6,7 @@
 
 #include <glm/glm.hpp>
 
+#include <functional>
 #include <memory>
 
 namespace pong

--- a/gameobjects/gameobject.h
+++ b/gameobjects/gameobject.h
@@ -42,6 +42,7 @@ public:
     void SetInstanceName(const std::string& name);
 
     bool CheckForCollision(GameObject& other);
+    void SetTimeout(int timeoutMs, std::function<void()> callback);
 
     void Render() const;
     template <typename T>

--- a/gameobjects/gameobject.h
+++ b/gameobjects/gameobject.h
@@ -6,6 +6,7 @@
 
 #include <glm/glm.hpp>
 
+#include <chrono>
 #include <functional>
 #include <memory>
 
@@ -43,7 +44,7 @@ public:
     void SetInstanceName(const std::string& name);
 
     bool CheckForCollision(GameObject& other);
-    void SetTimeout(int timeoutMs, std::function<void()> callback);
+    void SetTimeout(std::chrono::duration<double> timeout, std::function<void()> callback);
 
     void Render() const;
     template <typename T>

--- a/gameobjects/opponent.cpp
+++ b/gameobjects/opponent.cpp
@@ -2,6 +2,7 @@
 
 #include "pong.h"
 #include "rectangle.h"
+#include "timer.h"
 
 #include <glm/glm.hpp>
 
@@ -10,7 +11,7 @@ namespace pong
 
 static constexpr float OPPONENT_WIDTH = 15.0f;
 static constexpr float OPPONENT_HEIGHT = 125.0f;
-static constexpr float OPPONENT_SPEED = 6.0f;
+static constexpr float OPPONENT_SPEED = 850.0f;
 static constexpr glm::vec3 OPPONENT_POSITION(1125.0f, 0.0f, 0.0f);
 
 void Opponent::OnStart()
@@ -39,7 +40,7 @@ void Opponent::OnUpdate()
             mVelocity = glm::vec3(0.0f, -OPPONENT_SPEED, 0.0f);
         }
 
-        SetPosition(position + mVelocity);
+        SetPosition(position + mVelocity * Timer::frameTime);
     }
 }
 
@@ -48,7 +49,7 @@ void Opponent::OnCollisionStart(GameObject& other)
     if (other.GetInstanceName() == "Wall")
     {
         // Undo movement to stop from going through wall
-        SetPosition(GetPosition() - mVelocity);
+        SetPosition(GetPosition() - mVelocity * Timer::frameTime);
     }
 }
 

--- a/gameobjects/player.cpp
+++ b/gameobjects/player.cpp
@@ -3,13 +3,14 @@
 #include "gameobject.h"
 #include "input.h"
 #include "rectangle.h"
+#include "timer.h"
 
 #include <glm/glm.hpp>
 
 namespace pong
 {
 
-static constexpr float PLAYER_SPEED = 6.0f;
+static constexpr float PLAYER_SPEED = 850.0f;
 static constexpr glm::vec3 PLAYER_POSITION(-1125.0f, 0.0f, 0.0f);
 
 void Player::OnStart()
@@ -33,7 +34,7 @@ void Player::OnUpdate()
         mVelocity = glm::vec3(0.0f, -PLAYER_SPEED, 0.0f);
     }
 
-    SetPosition(GetPosition() + mVelocity);
+    SetPosition(GetPosition() + mVelocity * Timer::frameTime);
 }
 
 void Player::OnCollisionStart(GameObject& other)
@@ -41,7 +42,7 @@ void Player::OnCollisionStart(GameObject& other)
     if (other.GetInstanceName() == "Wall")
     {
         // Undo movement to stop from going through wall
-        SetPosition(GetPosition() - mVelocity);
+        SetPosition(GetPosition() - mVelocity * Timer::frameTime);
     }
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 #include "pong.h"
 #include "renderer.h"
 #include "renderutils.h"
+#include "timer.h"
 
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>


### PR DESCRIPTION
After the ball scores, things should wait for a minute before starting the game again. So, a timer is needed to call the ResetBall() function a few seconds after scoring. This Timer class holds requests involving a function callback and a timeout, keep track of when this should be called by keeping track of processing time between frames and call when ready.

Additionally, this introduces Timer::frameTime. This variable measures the processing time from the previous frame to this one. This is used in calulations to accomplish things over time to make them framerate independent. Ex. movement. A movement addition vector to position in OnUpdate() should be multiplied by this value otherwise running OnUpdate() more times (for higher framerates) will result in more additions to position in a second.