### PR TITLE
Add settings screen, and slider and checkbox ui elements.

### DIFF
--- a/engine/audiomixer.cpp
+++ b/engine/audiomixer.cpp
@@ -33,7 +33,7 @@ int AudioCallbackWrapper(const void* inputBuffer, void* outputBuffer,
 void AudioMixer::Init()
 {
     mVolume = Config::GetValue("volume", 0.5f);
-    LogInfo("Volume: {}", mVolume);
+    LogInfo("Volume: {}", mVolume.load());
 
     mSpatialAudioEnabled = Config::GetValue("spatial_audio", false);
     LogInfo("Spatial Audio: {}", mSpatialAudioEnabled ? "Enabled" : "Disabled");
@@ -172,6 +172,11 @@ int AudioMixer::AudioCallback(const void* /*inputBuffer*/, void* outputBuffer,
     mPlayingSoundsMutex.unlock();
 
     return paContinue;
+}
+
+void AudioMixer::SetVolume(float volume)
+{
+    mVolume = volume;
 }
 
 } // namespace pong

--- a/engine/audiomixer.cpp
+++ b/engine/audiomixer.cpp
@@ -32,12 +32,6 @@ int AudioCallbackWrapper(const void* inputBuffer, void* outputBuffer,
 
 void AudioMixer::Init()
 {
-    mVolume = Config::GetValue("volume", 0.5f);
-    LogInfo("Volume: {}", mVolume.load());
-
-    mSpatialAudioEnabled = Config::GetValue("spatial_audio", false);
-    LogInfo("Spatial Audio: {}", mSpatialAudioEnabled ? "Enabled" : "Disabled");
-
     PaError err = Pa_Initialize();
     if (err != paNoError) {
         LogError("PortAudio initialization failed: {}", Pa_GetErrorText(err));
@@ -174,9 +168,24 @@ int AudioMixer::AudioCallback(const void* /*inputBuffer*/, void* outputBuffer,
     return paContinue;
 }
 
+float AudioMixer::GetVolume() const
+{
+    return mVolume;
+}
+
 void AudioMixer::SetVolume(float volume)
 {
     mVolume = volume;
+}
+
+bool AudioMixer::GetSpatialAudioEnabled() const
+{
+    return mSpatialAudioEnabled;
+}
+
+void AudioMixer::SetSpatialAudioEnabled(bool enabled)
+{
+    mSpatialAudioEnabled = enabled;
 }
 
 } // namespace pong

--- a/engine/audiomixer.h
+++ b/engine/audiomixer.h
@@ -39,7 +39,7 @@ private:
     std::vector<PlayingSound> mPlayingSounds {};
     std::mutex mPlayingSoundsMutex {};
     std::atomic<float> mVolume { 0.75f };
-    bool mSpatialAudioEnabled { false };
+    std::atomic<bool> mSpatialAudioEnabled { false };
 };
 
 } // namespace pong

--- a/engine/audiomixer.h
+++ b/engine/audiomixer.h
@@ -6,6 +6,7 @@
 
 #include <portaudio.h>
 
+#include <atomic>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -28,11 +29,13 @@ public:
                     PaStreamCallbackFlags statusFlags,
                     void* userData);
 
+    void SetVolume(float volume);
+
 private:
     PaStream* mStream { nullptr };
     std::vector<PlayingSound> mPlayingSounds {};
     std::mutex mPlayingSoundsMutex {};
-    float mVolume { 0.5f };
+    std::atomic<float> mVolume { 0.5f };
     bool mSpatialAudioEnabled { false };
 };
 

--- a/engine/audiomixer.h
+++ b/engine/audiomixer.h
@@ -29,13 +29,16 @@ public:
                     PaStreamCallbackFlags statusFlags,
                     void* userData);
 
+    float GetVolume() const;
     void SetVolume(float volume);
+    bool GetSpatialAudioEnabled() const;
+    void SetSpatialAudioEnabled(bool enabled);
 
 private:
     PaStream* mStream { nullptr };
     std::vector<PlayingSound> mPlayingSounds {};
     std::mutex mPlayingSoundsMutex {};
-    std::atomic<float> mVolume { 0.5f };
+    std::atomic<float> mVolume { 0.75f };
     bool mSpatialAudioEnabled { false };
 };
 

--- a/engine/input.cpp
+++ b/engine/input.cpp
@@ -35,23 +35,23 @@ void Input::Init(GLFWwindow* window)
 
 void Input::Update()
 {
-    const auto updateInputState = [](InputState* inputStates, size_t size)
+    const auto updateInputState = [](auto& inputStatesArray)
     {
-        for (int i = 0; i < size; ++i)
+        for (auto& state : inputStatesArray)
         {
-            if (inputStates[i] == InputState::Pressed)
+            if (state == InputState::Pressed)
             {
-                inputStates[i] = InputState::Held;
+                state = InputState::Held;
             }
-            else if (inputStates[i] == InputState::Released)
+            else if (state == InputState::Released)
             {
-                inputStates[i] = InputState::NotPressed;
+                state = InputState::NotPressed;
             }
         }
     };
 
-    updateInputState(mKeys.data(), mKeys.size());
-    updateInputState(mMouseButtons.data(), mMouseButtons.size());
+    updateInputState(mKeys);
+    updateInputState(mMouseButtons);
 }
 
 void Input::KeyCallback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action, int /*mods*/)

--- a/engine/input.h
+++ b/engine/input.h
@@ -9,19 +9,36 @@
 namespace pong
 {
 
+// Reprsents the state of the key or mouse button on the current frame
+enum class InputState
+{
+    Pressed,
+    Held,
+    Released,
+    NotPressed
+};
+
 class Input
 {
 public:
-    static bool IsKeyPressed(unsigned int keycode);
+    static void Init(GLFWwindow* window);
+    static void Update();
     static void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
-    static glm::vec3 GetMousePosition();
-    static void MousePositionCallback(GLFWwindow* window, double xpos, double ypos);
-    static bool IsMouseButtonPressed(unsigned int button);
+    static bool IsKeyPressed(unsigned int keycode);
+    static InputState GetKeyState(unsigned int keycode);
+    static bool CheckKeyDown(unsigned int keycode);
+    static bool CheckKeyUp(unsigned int keycode);
+
     static void MouseButtonCallback(GLFWwindow* window, int button, int action, int mods);
+    static void MousePositionCallback(GLFWwindow* window, double xpos, double ypos);
+    static glm::vec3 GetMousePosition();
+    static InputState GetMouseButtonState(unsigned int button);
+    static bool CheckMouseButtonDown(unsigned int button);
+    static bool CheckMouseButtonUp(unsigned int button);
 
 private:
-    static std::array<bool, GLFW_KEY_LAST + 1> mKeys;
-    static std::array<bool, GLFW_MOUSE_BUTTON_LAST + 1> mMouseButtons;
+    static std::array<InputState, GLFW_KEY_LAST + 1> mKeys;
+    static std::array<InputState, GLFW_MOUSE_BUTTON_LAST + 1> mMouseButtons;
     static glm::vec3 mMousePosition;
 };
 

--- a/engine/mesh.cpp
+++ b/engine/mesh.cpp
@@ -13,7 +13,20 @@ namespace pong
 
 void Mesh::Draw(const glm::vec3& position) const
 {
-    Renderer::Draw(mVA, mIB, position, mTexture, mColor);
+    if (mEnabled)
+    {
+        Renderer::Draw(mVA, mIB, position, mTexture, mColor);
+    }
+}
+
+void Mesh::SetEnabled(bool enabled)
+{
+    mEnabled = enabled;
+}
+
+bool Mesh::IsEnabled() const
+{
+    return mEnabled;
 }
 
 void Mesh::SetColor(const GLRGBAColor& color)

--- a/engine/mesh.h
+++ b/engine/mesh.h
@@ -18,6 +18,8 @@ class Mesh
 public:
     virtual void Draw(const glm::vec3& position) const;
 
+    void SetEnabled(bool enabled);
+    bool IsEnabled() const;
     void SetColor(const GLRGBAColor& color);
 
 protected:
@@ -26,6 +28,7 @@ protected:
     IndexBuffer mIB {};
     Texture mTexture {};
     GLRGBAColor mColor { RGBA_WHITE };
+    bool mEnabled { true };
 };
 
 } // namespace pong

--- a/engine/pong.cpp
+++ b/engine/pong.cpp
@@ -8,6 +8,7 @@
 #include "player.h"
 #include "scorearea.h"
 #include "scorecontroller.h"
+#include "settingsscreencontroller.h"
 #include "titlescreencontroller.h"
 #include "wall.h"
 
@@ -108,6 +109,8 @@ void Pong::LoadScene(Scene scene)
         }
         case Scene::Settings:
         {
+            auto settingsScreen = std::make_unique<SettingsScreenController>();
+            GetInstance().mGameObjects.push_back(std::move(settingsScreen));
             break;
         }
         case Scene::Game:

--- a/engine/pong.cpp
+++ b/engine/pong.cpp
@@ -3,6 +3,7 @@
 #include "ball.h"
 #include "colliderbox.h"
 #include "config.h"
+#include "input.h"
 #include "logger.h"
 #include "opponent.h"
 #include "player.h"
@@ -75,6 +76,10 @@ void Pong::GameLoop()
     {
         uiElements->Render();
     }
+
+    // Done last because input callbacks are done in glfwPollEvents after this loop.
+    // So this effectively keeps the values from the new frame before updated from pressed -> held
+    Input::Update();
 }
 
 void Pong::Reset()

--- a/engine/processeventvisitor.h
+++ b/engine/processeventvisitor.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace pong
+{
+
+class Button;
+class CheckBox;
+class Slider;
+class Text;
+
+class ProcessEventVisitor
+{
+public:
+    virtual void VisitButton(Button& button) = 0;
+    virtual void VisitCheckBox(CheckBox& checkBox) = 0;
+    virtual void VisitSlider(Slider& slider) = 0;
+    virtual void VisitText(Text& text) = 0;
+};
+
+} // namespace pong

--- a/engine/processeventvisitor.h
+++ b/engine/processeventvisitor.h
@@ -11,10 +11,10 @@ class Text;
 class ProcessEventVisitor
 {
 public:
-    virtual void VisitButton(Button& button) = 0;
-    virtual void VisitCheckBox(CheckBox& checkBox) = 0;
-    virtual void VisitSlider(Slider& slider) = 0;
-    virtual void VisitText(Text& text) = 0;
+    virtual void Visit(Button& button) = 0;
+    virtual void Visit(CheckBox& checkBox) = 0;
+    virtual void Visit(Slider& slider) = 0;
+    virtual void Visit(Text& text) = 0;
 };
 
 } // namespace pong

--- a/engine/uieventmanager.cpp
+++ b/engine/uieventmanager.cpp
@@ -1,6 +1,7 @@
 #include "uieventmanager.h"
 
 #include "button.h"
+#include "checkbox.h"
 #include "colliderbox.h"
 #include "logger.h"
 #include "input.h"
@@ -21,21 +22,21 @@ void UIEventManager::ProcessEvents(const UIElementCollection& uiElements)
         case UIElementType::Button:
         {
             auto& button = static_cast<Button&>(*uiElement);
-            if (button.GetColliderBox()->CheckPointInBounds(mousePosition))
+
+            const bool inBounds = button.GetColliderBox()->CheckPointInBounds(mousePosition);
+            const InputState mouseButtonState = Input::GetMouseButtonState(GLFW_MOUSE_BUTTON_LEFT);
+            if (inBounds)
             {
                 if (!button.WasHovered())
                 {
                     button.OnEvent(ButtonEvent::Hover);
                 }
 
-                if (Input::IsMouseButtonPressed(GLFW_MOUSE_BUTTON_LEFT))
+                if (mouseButtonState == InputState::Pressed)
                 {
-                    if (!button.WasPressed())
-                    {
-                        button.OnEvent(ButtonEvent::Pressed);
-                    }
+                    button.OnEvent(ButtonEvent::Pressed);
                 }
-                else if (button.WasPressed())
+                else if (mouseButtonState == InputState::Released)
                 {
                     button.OnEvent(ButtonEvent::Release);
                 }
@@ -46,13 +47,21 @@ void UIEventManager::ProcessEvents(const UIElementCollection& uiElements)
             }
             break;
         }
+        case UIElementType::CheckBox:
+        {
+            auto& checkBox = static_cast<CheckBox&>(*uiElement);
+            if (checkBox.GetColliderBox()->CheckPointInBounds(mousePosition) && Input::GetMouseButtonState(GLFW_MOUSE_BUTTON_LEFT) == InputState::Pressed)
+            {
+                checkBox.OnClick();
+            }
+            break;
+        }
         case UIElementType::Slider:
         {
-            //LogInfo("Slider");
             auto& slider = static_cast<Slider&>(*uiElement);
 
             const bool inBounds = slider.GetColliderBox()->CheckPointInBounds(mousePosition);
-            const bool mousePressed = Input::IsMouseButtonPressed(GLFW_MOUSE_BUTTON_LEFT);
+            const bool mousePressed = Input::CheckMouseButtonDown(GLFW_MOUSE_BUTTON_LEFT);
 
             if ((inBounds && mousePressed) || (mousePressed && slider.WasPressed()))
             {

--- a/engine/uieventmanager.cpp
+++ b/engine/uieventmanager.cpp
@@ -4,6 +4,7 @@
 #include "colliderbox.h"
 #include "logger.h"
 #include "input.h"
+#include "slider.h"
 #include "uielement.h"
 
 namespace pong
@@ -15,34 +16,58 @@ void UIEventManager::ProcessEvents(const UIElementCollection& uiElements)
 
     for (auto& uiElement : uiElements)
     {
-        if (uiElement->GetType() != UIElementType::Button)
+        switch (uiElement->GetType())
         {
-            continue;
-        }
-
-        auto& button = static_cast<Button&>(*uiElement);
-        if (button.GetColliderBox()->CheckPointInBounds(mousePosition))
+        case UIElementType::Button:
         {
-            if (!button.WasHovered())
+            auto& button = static_cast<Button&>(*uiElement);
+            if (button.GetColliderBox()->CheckPointInBounds(mousePosition))
             {
-                button.OnEvent(ButtonEvent::Hover);
-            }
-
-            if (Input::IsMouseButtonPressed(GLFW_MOUSE_BUTTON_LEFT))
-            {
-                if (!button.WasPressed())
+                if (!button.WasHovered())
                 {
-                    button.OnEvent(ButtonEvent::Pressed);
+                    button.OnEvent(ButtonEvent::Hover);
+                }
+
+                if (Input::IsMouseButtonPressed(GLFW_MOUSE_BUTTON_LEFT))
+                {
+                    if (!button.WasPressed())
+                    {
+                        button.OnEvent(ButtonEvent::Pressed);
+                    }
+                }
+                else if (button.WasPressed())
+                {
+                    button.OnEvent(ButtonEvent::Release);
                 }
             }
-            else if (button.WasPressed())
+            else if (button.WasHovered())
             {
-                button.OnEvent(ButtonEvent::Release);
+                button.OnEvent(ButtonEvent::Unhover);
             }
+            break;
         }
-        else if (button.WasHovered())
+        case UIElementType::Slider:
         {
-            button.OnEvent(ButtonEvent::Unhover);
+            //LogInfo("Slider");
+            auto& slider = static_cast<Slider&>(*uiElement);
+
+            const bool inBounds = slider.GetColliderBox()->CheckPointInBounds(mousePosition);
+            const bool mousePressed = Input::IsMouseButtonPressed(GLFW_MOUSE_BUTTON_LEFT);
+
+            if (inBounds && mousePressed)
+            {
+                slider.OnMouseHeld(mousePosition);
+            }
+            else if (inBounds && !mousePressed && slider.WasPressed())
+            {
+                slider.OnMouseReleased();
+            }
+            break;
+        }
+        case UIElementType::Text:
+            break;
+        default:
+            break;
         }
     }
 }

--- a/engine/uieventmanager.cpp
+++ b/engine/uieventmanager.cpp
@@ -54,11 +54,11 @@ void UIEventManager::ProcessEvents(const UIElementCollection& uiElements)
             const bool inBounds = slider.GetColliderBox()->CheckPointInBounds(mousePosition);
             const bool mousePressed = Input::IsMouseButtonPressed(GLFW_MOUSE_BUTTON_LEFT);
 
-            if (inBounds && mousePressed)
+            if ((inBounds && mousePressed) || (mousePressed && slider.WasPressed()))
             {
                 slider.OnMouseHeld(mousePosition);
             }
-            else if (inBounds && !mousePressed && slider.WasPressed())
+            else if (!mousePressed && slider.WasPressed())
             {
                 slider.OnMouseReleased();
             }

--- a/engine/uieventmanager.cpp
+++ b/engine/uieventmanager.cpp
@@ -11,7 +11,7 @@
 namespace pong
 {
 
-void UIEventManager::VisitButton(Button& button)
+void UIEventManager::Visit(Button& button)
 {
     const glm::vec3 mousePosition = Input::GetMousePosition();
     const bool inBounds = button.GetColliderBox()->CheckPointInBounds(mousePosition);
@@ -39,7 +39,7 @@ void UIEventManager::VisitButton(Button& button)
     }
 }
 
-void UIEventManager::VisitCheckBox(CheckBox& checkBox)
+void UIEventManager::Visit(CheckBox& checkBox)
 {
     const glm::vec3 mousePosition = Input::GetMousePosition();
     if (checkBox.GetColliderBox()->CheckPointInBounds(mousePosition) && Input::GetMouseButtonState(GLFW_MOUSE_BUTTON_LEFT) == InputState::Pressed)
@@ -48,7 +48,7 @@ void UIEventManager::VisitCheckBox(CheckBox& checkBox)
     }
 }
 
-void UIEventManager::VisitSlider(Slider& slider)
+void UIEventManager::Visit(Slider& slider)
 {
     const glm::vec3 mousePosition = Input::GetMousePosition();
     const bool inBounds = slider.GetColliderBox()->CheckPointInBounds(mousePosition);
@@ -64,7 +64,7 @@ void UIEventManager::VisitSlider(Slider& slider)
     }
 }
 
-void UIEventManager::VisitText(Text& /*text*/)
+void UIEventManager::Visit(Text& /*text*/)
 {
     // No events to process on text objects
 }

--- a/engine/uieventmanager.cpp
+++ b/engine/uieventmanager.cpp
@@ -65,7 +65,7 @@ void UIEventManager::ProcessEvents(const UIElementCollection& uiElements)
 
             if ((inBounds && mousePressed) || (mousePressed && slider.WasPressed()))
             {
-                slider.OnMouseHeld(mousePosition);
+                slider.OnMouseDown(mousePosition);
             }
             else if (!mousePressed && slider.WasPressed())
             {

--- a/engine/uieventmanager.h
+++ b/engine/uieventmanager.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include "button.h"
+#include "checkbox.h"
+#include "slider.h"
 #include "uielement.h"
+#include "processeventvisitor.h"
 
 #include <memory>
 #include <vector>
@@ -10,9 +14,14 @@ namespace pong
 
 using UIElementCollection = std::vector<std::unique_ptr<UIElement>>;
 
-class UIEventManager
+class UIEventManager : public ProcessEventVisitor
 {
 public:
+    void VisitButton(Button& button) override;
+    void VisitCheckBox(CheckBox& checkBox) override;
+    void VisitSlider(Slider& slider) override;
+    void VisitText(Text& text) override;
+
     void ProcessEvents(const UIElementCollection& uiElements);
 };
 

--- a/engine/uieventmanager.h
+++ b/engine/uieventmanager.h
@@ -17,10 +17,10 @@ using UIElementCollection = std::vector<std::unique_ptr<UIElement>>;
 class UIEventManager : public ProcessEventVisitor
 {
 public:
-    void VisitButton(Button& button) override;
-    void VisitCheckBox(CheckBox& checkBox) override;
-    void VisitSlider(Slider& slider) override;
-    void VisitText(Text& text) override;
+    void Visit(Button& button) override;
+    void Visit(CheckBox& checkBox) override;
+    void Visit(Slider& slider) override;
+    void Visit(Text& text) override;
 
     void ProcessEvents(const UIElementCollection& uiElements);
 };

--- a/gameobjects/CMakeLists.txt
+++ b/gameobjects/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     scorecontroller.cpp
     settingsscreencontroller.cpp
     titlescreencontroller.cpp
+    uimenu.cpp
     wall.cpp
 )
 

--- a/gameobjects/CMakeLists.txt
+++ b/gameobjects/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     player.cpp
     scorearea.cpp
     scorecontroller.cpp
+    settingsscreencontroller.cpp
     titlescreencontroller.cpp
     wall.cpp
 )

--- a/gameobjects/player.cpp
+++ b/gameobjects/player.cpp
@@ -25,11 +25,11 @@ void Player::OnUpdate()
 {
     mVelocity = glm::vec3(0.0f);
 
-    if (Input::IsKeyPressed(GLFW_KEY_W))
+    if (Input::CheckKeyDown(GLFW_KEY_W))
     {
         mVelocity = glm::vec3(0.0f, PLAYER_SPEED, 0.0f);
     }
-    else if (Input::IsKeyPressed(GLFW_KEY_S))
+    else if (Input::CheckKeyDown(GLFW_KEY_S))
     {
         mVelocity = glm::vec3(0.0f, -PLAYER_SPEED, 0.0f);
     }

--- a/gameobjects/settingsscreencontroller.cpp
+++ b/gameobjects/settingsscreencontroller.cpp
@@ -1,39 +1,78 @@
 #include "settingsscreencontroller.h"
 
+#include "checkbox.h"
 #include "config.h"
+#include "difficulty.h"
 #include "pong.h"
 
 namespace pong
 {
 
-constexpr float STARTING_VOLUME = 0.5f;
+constexpr float VOLUME_MIN = 0.0f;
+constexpr float VOLUME_MAX = 1.0f;
+constexpr float VOLUME_STEP = 0.01f;
 
 void SettingsScreenController::OnStart()
 {
     mSettingsText = Pong::AddUIElement<Text>("Settings", Config::GetValue<std::string>("font"), 1.5f, 256);
     mSettingsText->SetPosition(glm::vec3(0.0f, 750.0f, 0.0f));
 
-    mBackButton = Pong::AddUIElement<Button>(400.0f, 200.0f);
-    mBackButton->SetPosition(glm::vec3(-900.0f, -700.0f, 0.0f));
+    mBackText = Pong::AddUIElement<Text>("Back", Config::GetValue<std::string>("font"), 1.0f, 75);
+    mBackButton = Pong::AddUIElement<Button>(300.0f, 150.0f);
     mBackButton->AddListener(ButtonEvent::Pressed, []() {
         Pong::LoadSceneNext(Scene::TitleScreen);
     });
+    SetupButton(mBackButton, mBackText, glm::vec3(-950.0f, -750.0f, 0.0f));
 
-    mBackText = Pong::AddUIElement<Text>("Back", Config::GetValue<std::string>("font"), 1.0f, 75);
-    mBackText->SetOrderLayer(1);
-    mBackText->SetColor({ 0.0f, 0.0f, 0.0f, 1.0f });
-    mBackText->SetPosition(glm::vec3(-900.0f, -700.0f, 0.0f));
+    const float startVolume = Pong::GetInstance().GetAudioMixer().GetVolume();
+    mVolumeText = Pong::AddUIElement<Text>("Volume: " + std::to_string(static_cast<int>(startVolume * 100)), Config::GetValue<std::string>("font"), 1.0f, 75);
+    mVolumeText->SetPosition(glm::vec3(-750.0f, -450.0f, 0.0f));
 
-    mVolumeText = Pong::AddUIElement<Text>("Volume: " + std::to_string(static_cast<int>(STARTING_VOLUME * 100)), Config::GetValue<std::string>("font"), 1.0f, 75);
-    mVolumeText->SetOrderLayer(1);
-    mVolumeText->SetPosition(glm::vec3(-450.0f, 0.0f, 0.0f));
-
-    mVolumeSlider = Pong::AddUIElement<Slider>(1000.0f, 100.0f, 0.0f, 1.0f, 0.01f, STARTING_VOLUME);
-    mVolumeSlider->SetPosition(glm::vec3(300.0f, 0.0f, 0.0f));
-    mVolumeSlider->AddValueChangeListener([this](float newValue) {
+    mVolumeSlider = Pong::AddUIElement<Slider>(1000.0f, 100.0f, VOLUME_MIN, VOLUME_MAX, VOLUME_STEP, startVolume);
+    mVolumeSlider->SetPosition(glm::vec3(200.0f, -450.0f, 0.0f));
+    mVolumeSlider->AddValueChangeListener([this] (float newValue) {
         Pong::GetInstance().GetAudioMixer().SetVolume(newValue);
         this->mVolumeText->SetText("Volume: " + std::to_string(static_cast<int>(newValue * 100)));
     });
+
+    mSpatialAudioText = Pong::AddUIElement<Text>("Spatial Audio", Config::GetValue<std::string>("font"), 1.0f, 75);
+    mSpatialAudioText->SetPosition(glm::vec3(-750.0f, 150.0f, 0.0f));
+
+    mSpatialAudio = Pong::AddUIElement<CheckBox>(100.0f, 100.0f, Pong::GetInstance().GetAudioMixer().GetSpatialAudioEnabled());
+    mSpatialAudio->SetPosition(glm::vec3(200.0f, 150.0f, 0.0f));
+    mSpatialAudio->AddValueChangeListener([] (bool value) {
+        Pong::GetInstance().GetAudioMixer().SetSpatialAudioEnabled(value);
+    });
+
+    mDifficultyText = Pong::AddUIElement<Text>("Difficulty", Config::GetValue<std::string>("font"), 1.0f, 75);
+    mDifficultyText->SetPosition(glm::vec3(-750.0f, 0.0f, 0.0f));
+
+    const Difficulty::Level currentDifficulty = Difficulty::GetLevel();
+    const std::array<std::string, 4> difficultyNames = { "Easy", "Medium", "Hard", "Impossible" };
+
+    for (int i = 0; i < 4; i++)
+    {
+        const float x = i % 2 * 550.0f;
+        const float y = (i < 2) * 150.0f;
+        mDifficultyTexts[i] = Pong::AddUIElement<Text>(difficultyNames[i], Config::GetValue<std::string>("font"), 1.0f, 75);
+        mDifficultyTexts[i]->SetPosition(glm::vec3(-75.0f + x, 0.0f - y, 0.0f));
+
+        mDifficultyCheckBoxes[i] = Pong::AddUIElement<CheckBox>(100.0f, 100.0f, currentDifficulty == static_cast<Difficulty::Level>(i));
+        mDifficultyCheckBoxes[i]->SetPosition(glm::vec3(200.0f + x, 0.0f - y, 0.0f));
+        mDifficultyCheckBoxes[i]->AddValueChangeListener([&, i] (bool value) {
+            if (value)
+            {
+                Difficulty::SetLevel(static_cast<Difficulty::Level>(i));
+                for (auto& checkBox : mDifficultyCheckBoxes)
+                {
+                    if (checkBox != mDifficultyCheckBoxes[i])
+                    {
+                        checkBox->SetValue(false);
+                    }
+                }
+            }
+        });
+    }
 }
 
 } // namespace pong

--- a/gameobjects/settingsscreencontroller.cpp
+++ b/gameobjects/settingsscreencontroller.cpp
@@ -8,52 +8,67 @@
 namespace pong
 {
 
-constexpr float VOLUME_MIN = 0.0f;
-constexpr float VOLUME_MAX = 1.0f;
-constexpr float VOLUME_STEP = 0.01f;
+static constexpr float VOLUME_MIN = 0.0f;
+static constexpr float VOLUME_MAX = 1.0f;
+static constexpr float VOLUME_STEP = 0.01f;
+
+static constexpr glm::vec3 SETTINGS_TEXT_POSITION = glm::vec3(0.0f, 750.0f, 0.0f);
+static constexpr glm::vec3 BACK_TEXT_POSITION = glm::vec3(-950.0f, -750.0f, 0.0f);
+static constexpr glm::vec3 BACK_BUTTON_POSITION = glm::vec3(-950.0f, -750.0f, 0.0f);
+static constexpr glm::vec3 VOLUME_TEXT_POSITION = glm::vec3(-750.0f, -450.0f, 0.0f);
+static constexpr glm::vec3 VOLUME_SLIDER_POSITION = glm::vec3(200.0f, -450.0f, 0.0f);
+static constexpr glm::vec3 SPATIAL_AUDIO_TEXT_POSITION = glm::vec3(-750.0f, 150.0f, 0.0f);
+static constexpr glm::vec3 SPATIAL_AUDIO_CHECKBOX_POSITION = glm::vec3(200.0f, 150.0f, 0.0f);
+static constexpr glm::vec3 DIFFICULTY_TEXT_POSITION = glm::vec3(-750.0f, 0.0f, 0.0f);
+
+static constexpr float DIFFICULTY_SPREAD_H = 550.0f;
+static constexpr float DIFFICULTY_SPREAD_V = 150.0f;
+
 
 void SettingsScreenController::OnStart()
 {
-    mSettingsText = Pong::AddUIElement<Text>("Settings", Config::GetValue<std::string>("font"), 1.5f, 256);
-    mSettingsText->SetPosition(glm::vec3(0.0f, 750.0f, 0.0f));
+    const std::string font = Config::GetValue<std::string>("font");
 
-    mBackText = Pong::AddUIElement<Text>("Back", Config::GetValue<std::string>("font"), 1.0f, 75);
+    mSettingsText = Pong::AddUIElement<Text>("Settings", font, 1.5f, 256);
+    mSettingsText->SetPosition(SETTINGS_TEXT_POSITION);
+
+    mBackText = Pong::AddUIElement<Text>("Back", font, 1.0f, 75);
     mBackButton = Pong::AddUIElement<Button>(300.0f, 150.0f);
     mBackButton->AddListener(ButtonEvent::Pressed, []() {
         Pong::LoadSceneNext(Scene::TitleScreen);
     });
-    SetupButton(mBackButton, mBackText, glm::vec3(-950.0f, -750.0f, 0.0f));
+    SetupButton(mBackButton, mBackText, BACK_BUTTON_POSITION);
 
     const float startVolume = Pong::GetInstance().GetAudioMixer().GetVolume();
-    mVolumeText = Pong::AddUIElement<Text>("Volume: " + std::to_string(static_cast<int>(startVolume * 100)), Config::GetValue<std::string>("font"), 1.0f, 75);
-    mVolumeText->SetPosition(glm::vec3(-750.0f, -450.0f, 0.0f));
+    mVolumeText = Pong::AddUIElement<Text>("Volume: " + std::to_string(static_cast<int>(startVolume * 100)), font, 1.0f, 75);
+    mVolumeText->SetPosition(VOLUME_TEXT_POSITION);
 
     mVolumeSlider = Pong::AddUIElement<Slider>(1000.0f, 100.0f, VOLUME_MIN, VOLUME_MAX, VOLUME_STEP, startVolume);
-    mVolumeSlider->SetPosition(glm::vec3(200.0f, -450.0f, 0.0f));
+    mVolumeSlider->SetPosition(VOLUME_SLIDER_POSITION);
     mVolumeSlider->AddValueChangeListener([this] (float newValue) {
         Pong::GetInstance().GetAudioMixer().SetVolume(newValue);
         this->mVolumeText->SetText("Volume: " + std::to_string(static_cast<int>(newValue * 100)));
     });
 
-    mSpatialAudioText = Pong::AddUIElement<Text>("Spatial Audio", Config::GetValue<std::string>("font"), 1.0f, 75);
-    mSpatialAudioText->SetPosition(glm::vec3(-750.0f, 150.0f, 0.0f));
+    mSpatialAudioText = Pong::AddUIElement<Text>("Spatial Audio", font, 1.0f, 75);
+    mSpatialAudioText->SetPosition(SPATIAL_AUDIO_TEXT_POSITION);
 
     mSpatialAudio = Pong::AddUIElement<CheckBox>(100.0f, 100.0f, Pong::GetInstance().GetAudioMixer().GetSpatialAudioEnabled());
-    mSpatialAudio->SetPosition(glm::vec3(200.0f, 150.0f, 0.0f));
+    mSpatialAudio->SetPosition(SPATIAL_AUDIO_CHECKBOX_POSITION);
     mSpatialAudio->AddValueChangeListener([] (bool value) {
         Pong::GetInstance().GetAudioMixer().SetSpatialAudioEnabled(value);
     });
 
-    mDifficultyText = Pong::AddUIElement<Text>("Difficulty", Config::GetValue<std::string>("font"), 1.0f, 75);
-    mDifficultyText->SetPosition(glm::vec3(-750.0f, 0.0f, 0.0f));
+    mDifficultyText = Pong::AddUIElement<Text>("Difficulty", font, 1.0f, 75);
+    mDifficultyText->SetPosition(DIFFICULTY_TEXT_POSITION);
 
     const Difficulty::Level currentDifficulty = Difficulty::GetLevel();
     const std::array<std::string, 4> difficultyNames = { "Easy", "Medium", "Hard", "Impossible" };
 
     for (int i = 0; i < 4; i++)
     {
-        const float x = i % 2 * 550.0f;
-        const float y = (i < 2) * 150.0f;
+        const float x = i % 2 * DIFFICULTY_SPREAD_H;
+        const float y = (i < 2) * DIFFICULTY_SPREAD_V;
         mDifficultyTexts[i] = Pong::AddUIElement<Text>(difficultyNames[i], Config::GetValue<std::string>("font"), 1.0f, 75);
         mDifficultyTexts[i]->SetPosition(glm::vec3(-75.0f + x, 0.0f - y, 0.0f));
 

--- a/gameobjects/settingsscreencontroller.cpp
+++ b/gameobjects/settingsscreencontroller.cpp
@@ -1,0 +1,39 @@
+#include "settingsscreencontroller.h"
+
+#include "config.h"
+#include "pong.h"
+
+namespace pong
+{
+
+constexpr float STARTING_VOLUME = 0.5f;
+
+void SettingsScreenController::OnStart()
+{
+    mSettingsText = Pong::AddUIElement<Text>("Settings", Config::GetValue<std::string>("font"), 1.5f, 256);
+    mSettingsText->SetPosition(glm::vec3(0.0f, 750.0f, 0.0f));
+
+    mBackButton = Pong::AddUIElement<Button>(400.0f, 200.0f);
+    mBackButton->SetPosition(glm::vec3(-900.0f, -700.0f, 0.0f));
+    mBackButton->AddListener(ButtonEvent::Pressed, []() {
+        Pong::LoadSceneNext(Scene::TitleScreen);
+    });
+
+    mBackText = Pong::AddUIElement<Text>("Back", Config::GetValue<std::string>("font"), 1.0f, 75);
+    mBackText->SetOrderLayer(1);
+    mBackText->SetColor({ 0.0f, 0.0f, 0.0f, 1.0f });
+    mBackText->SetPosition(glm::vec3(-900.0f, -700.0f, 0.0f));
+
+    mVolumeText = Pong::AddUIElement<Text>("Volume: " + std::to_string(static_cast<int>(STARTING_VOLUME * 100)), Config::GetValue<std::string>("font"), 1.0f, 75);
+    mVolumeText->SetOrderLayer(1);
+    mVolumeText->SetPosition(glm::vec3(-450.0f, 0.0f, 0.0f));
+
+    mVolumeSlider = Pong::AddUIElement<Slider>(1000.0f, 100.0f, 0.0f, 1.0f, 0.01f, STARTING_VOLUME);
+    mVolumeSlider->SetPosition(glm::vec3(300.0f, 0.0f, 0.0f));
+    mVolumeSlider->AddValueChangeListener([this](float newValue) {
+        Pong::GetInstance().GetAudioMixer().SetVolume(newValue);
+        this->mVolumeText->SetText("Volume: " + std::to_string(static_cast<int>(newValue * 100)));
+    });
+}
+
+} // namespace pong

--- a/gameobjects/settingsscreencontroller.h
+++ b/gameobjects/settingsscreencontroller.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "button.h"
+#include "gameobject.h"
+#include "slider.h"
+#include "text.h"
+
+namespace pong
+{
+
+class SettingsScreenController : public GameObject
+{
+public:
+    void OnStart() override;
+
+private:
+    Text* mSettingsText { nullptr };
+    Button* mBackButton { nullptr };
+    Text* mBackText { nullptr };
+    Slider* mVolumeSlider { nullptr };
+    Text* mVolumeText { nullptr };
+};
+
+} // namespace pong

--- a/gameobjects/settingsscreencontroller.h
+++ b/gameobjects/settingsscreencontroller.h
@@ -1,14 +1,16 @@
 #pragma once
 
 #include "button.h"
+#include "checkbox.h"
 #include "gameobject.h"
 #include "slider.h"
 #include "text.h"
+#include "uimenu.h"
 
 namespace pong
 {
 
-class SettingsScreenController : public GameObject
+class SettingsScreenController : public GameObject, public UIMenu
 {
 public:
     void OnStart() override;
@@ -19,6 +21,11 @@ private:
     Text* mBackText { nullptr };
     Slider* mVolumeSlider { nullptr };
     Text* mVolumeText { nullptr };
+    CheckBox* mSpatialAudio { nullptr };
+    Text* mSpatialAudioText { nullptr };
+    Text* mDifficultyText { nullptr };
+    std::array<CheckBox*, 4> mDifficultyCheckBoxes {};
+    std::array<Text*, 4> mDifficultyTexts {};
 };
 
 } // namespace pong

--- a/gameobjects/titlescreencontroller.cpp
+++ b/gameobjects/titlescreencontroller.cpp
@@ -25,84 +25,26 @@ void TitleScreenController::OnStart()
     mPongText = Pong::AddUIElement<Text>("Pong", kFontPath, 1.5f, 256);
     mPongText->SetPosition(PONG_TEXT_POSITION);
 
-
-
+    mPlayText = Pong::AddUIElement<Text>("Play", kFontPath, 1.0f);
     mPlayButton = Pong::AddUIElement<Button>(BUTTON_WIDTH, BUTTON_HEIGHT);
-
     mPlayButton->AddListener(ButtonEvent::Pressed, []() {
         Pong::LoadSceneNext(Scene::Game);
     });
+    SetupButton(mPlayButton, mPlayText, glm::vec3(0.0f));
 
-    mPlayButton->AddListener(ButtonEvent::Hover, [this]() {
-        this->HoverOverButton(mPlayButton, mPlayText);
-    });
-
-    mPlayButton->AddListener(ButtonEvent::Unhover, [this]() {
-        this->UnhoverOverButton(mPlayButton, mPlayText);
-    });
-
-    mPlayText = Pong::AddUIElement<Text>("Play", kFontPath, 1.0f);
-    mPlayText->SetOrderLayer(1);
-    mPlayText->SetColor(IDLE_TEXT_COLOR);
-
-
-
+    mSettingsText = Pong::AddUIElement<Text>("Settings", kFontPath, 1.0f, 75);
     mSettingsButton = Pong::AddUIElement<Button>(BUTTON_WIDTH, BUTTON_HEIGHT);
-    mSettingsButton->SetPosition(SETTINGS_BUTTON_POSITION);
-
     mSettingsButton->AddListener(ButtonEvent::Pressed, []() {
         Pong::LoadSceneNext(Scene::Settings);
     });
+    SetupButton(mSettingsButton, mSettingsText, SETTINGS_BUTTON_POSITION);
 
-    mSettingsButton->AddListener(ButtonEvent::Hover, [this]() {
-        this->HoverOverButton(mSettingsButton, mSettingsText);
-    });
-
-    mSettingsButton->AddListener(ButtonEvent::Unhover, [this]() {
-        this->UnhoverOverButton(mSettingsButton, mSettingsText);
-    });
-
-    mSettingsText = Pong::AddUIElement<Text>("Settings", kFontPath, 1.0f, 75);
-    mSettingsText->SetOrderLayer(1);
-    mSettingsText->SetColor(IDLE_TEXT_COLOR);
-    mSettingsText->SetPosition(SETTINGS_BUTTON_POSITION);
-
-
-
+    mQuitText = Pong::AddUIElement<Text>("Quit", kFontPath, 1.0f, 75);
     mQuitButton = Pong::AddUIElement<Button>(BUTTON_WIDTH, BUTTON_HEIGHT);
-    mQuitButton->SetPosition(QUIT_BUTTON_POSITION);
-
     mQuitButton->AddListener(ButtonEvent::Pressed, []() {
         Pong::ExitGame();
     });
-
-    mQuitButton->AddListener(ButtonEvent::Hover, [this]() {
-        this->HoverOverButton(mQuitButton, mQuitText);
-    });
-
-    mQuitButton->AddListener(ButtonEvent::Unhover, [this]() {
-        this->UnhoverOverButton(mQuitButton, mQuitText);
-    });
-
-    mQuitText = Pong::AddUIElement<Text>("Quit", kFontPath, 1.0f, 75);
-    mQuitText->SetOrderLayer(1);
-    mQuitText->SetColor(IDLE_TEXT_COLOR);
-    mQuitText->SetPosition(QUIT_BUTTON_POSITION);
-
-    Slider* test = Pong::AddUIElement<Slider>(1000.0f, 100.0f, 0.0f, 100.0f, 1.0f, 76.0f);
-    test->SetPosition(glm::vec3(300.0f, 300.0f, 0.0f));
-}
-
-void TitleScreenController::HoverOverButton(Button* button, Text* buttonText)
-{
-    button->Resize(HOVER_BUTTON_WIDTH, HOVER_BUTTON_HEIGHT);
-    buttonText->SetColor(HOVER_TEXT_COLOR);
-}
-
-void TitleScreenController::UnhoverOverButton(Button* button, Text* buttonText)
-{
-    button->Resize(BUTTON_WIDTH, BUTTON_HEIGHT);
-    buttonText->SetColor(IDLE_TEXT_COLOR);
+    SetupButton(mQuitButton, mQuitText, QUIT_BUTTON_POSITION);
 }
 
 } // namespace pong

--- a/gameobjects/titlescreencontroller.cpp
+++ b/gameobjects/titlescreencontroller.cpp
@@ -89,8 +89,8 @@ void TitleScreenController::OnStart()
     mQuitText->SetColor(IDLE_TEXT_COLOR);
     mQuitText->SetPosition(QUIT_BUTTON_POSITION);
 
-    Slider* test = Pong::AddUIElement<Slider>(400.0f, 100.0f, 0.0f, 100.0f, 50.0f, 50.0f);
-    test->SetPosition(glm::vec3(600.0f, 300.0f, 0.0f));
+    Slider* test = Pong::AddUIElement<Slider>(1000.0f, 100.0f, 0.0f, 100.0f, 1.0f, 76.0f);
+    test->SetPosition(glm::vec3(300.0f, 300.0f, 0.0f));
 }
 
 void TitleScreenController::HoverOverButton(Button* button, Text* buttonText)

--- a/gameobjects/titlescreencontroller.cpp
+++ b/gameobjects/titlescreencontroller.cpp
@@ -1,8 +1,9 @@
 #include "titlescreencontroller.h"
 
 #include "button.h"
-#include "logger.h"
 #include "config.h"
+#include "logger.h"
+#include "slider.h"
 #include "pong.h"
 
 namespace pong
@@ -87,6 +88,9 @@ void TitleScreenController::OnStart()
     mQuitText->SetOrderLayer(1);
     mQuitText->SetColor(IDLE_TEXT_COLOR);
     mQuitText->SetPosition(QUIT_BUTTON_POSITION);
+
+    Slider* test = Pong::AddUIElement<Slider>(400.0f, 100.0f, 0.0f, 100.0f, 50.0f, 50.0f);
+    test->SetPosition(glm::vec3(600.0f, 300.0f, 0.0f));
 }
 
 void TitleScreenController::HoverOverButton(Button* button, Text* buttonText)

--- a/gameobjects/titlescreencontroller.h
+++ b/gameobjects/titlescreencontroller.h
@@ -3,19 +3,17 @@
 #include "button.h"
 #include "gameobject.h"
 #include "text.h"
+#include "uimenu.h"
 
 namespace pong
 {
 
-class TitleScreenController : public GameObject
+class TitleScreenController : public GameObject, public UIMenu
 {
 public:
     void OnStart() override;
 
 private:
-    void HoverOverButton(Button* button, Text* buttonText);
-    void UnhoverOverButton(Button* button, Text* buttonText);
-
     Text*   mPongText { nullptr };
     Button* mPlayButton { nullptr };
     Text*   mPlayText   { nullptr };

--- a/gameobjects/uimenu.cpp
+++ b/gameobjects/uimenu.cpp
@@ -1,0 +1,41 @@
+#include "uimenu.h"
+
+namespace pong
+{
+
+static constexpr GLRGBAColor IDLE_TEXT_COLOR = { 0.0f, 0.0f, 0.0f, 1.0f };
+static constexpr GLRGBAColor HOVER_TEXT_COLOR = { 0.4f, 0.4f, 0.4f, 1.0f };
+static constexpr float BUTTON_HOVER_SCALE = 1.35f;
+
+void UIMenu::SetupButton(Button* button, Text* buttonText, const glm::vec3& position)
+{
+    button->SetPosition(position);
+    buttonText->SetColor(IDLE_TEXT_COLOR);
+    buttonText->SetPosition(position);
+    buttonText->SetOrderLayer(1);
+
+    const float buttonWidth = button->GetWidth();
+    const float buttonHeight = button->GetHeight();
+
+    button->AddListener(ButtonEvent::Hover, [button, buttonText, buttonWidth, buttonHeight, this]() {
+        this->ButtonHoverAnimation(button, buttonText, buttonWidth * BUTTON_HOVER_SCALE, buttonHeight * BUTTON_HOVER_SCALE);
+    });
+
+    button->AddListener(ButtonEvent::Unhover, [button, buttonText, buttonWidth, buttonHeight, this]() {
+       this->ButtonUnhoverAnimation(button, buttonText, buttonWidth, buttonHeight);
+    });
+}
+
+void UIMenu::ButtonHoverAnimation(Button* button, Text* buttonText, float newWidth, float newHeight)
+{
+    button->Resize(newWidth, newHeight);
+    buttonText->SetColor(HOVER_TEXT_COLOR);
+}
+
+void UIMenu::ButtonUnhoverAnimation(Button* button, Text* buttonText, float newWidth, float newHeight)
+{
+    button->Resize(newWidth, newHeight);
+    buttonText->SetColor(IDLE_TEXT_COLOR);
+}
+
+} // namespace pong

--- a/gameobjects/uimenu.h
+++ b/gameobjects/uimenu.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "button.h"
+#include "text.h"
+
+namespace pong
+{
+
+class UIMenu
+{
+public:
+    void SetupButton(Button* button, Text* buttonText, const glm::vec3& position);
+    void ButtonHoverAnimation(Button* button, Text* buttonText, float newWidth, float newHeight);
+    void ButtonUnhoverAnimation(Button* button, Text* buttonText, float newWidth, float newHeight);
+};
+
+} // namespace pong

--- a/main.cpp
+++ b/main.cpp
@@ -40,9 +40,7 @@ GLFWwindow* SetupGLFW()
     }
 
     glfwMakeContextCurrent(window);
-    glfwSetKeyCallback(window, Input::KeyCallback);
-    glfwSetCursorPosCallback(window, Input::MousePositionCallback);
-    glfwSetMouseButtonCallback(window, Input::MouseButtonCallback);
+    Input::Init(window);
 
     if (glewInit() != GLEW_OK)
     {

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     button.cpp
+    slider.cpp
     text.cpp
     uielement.cpp
 )

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     button.cpp
+    checkbox.cpp
     slider.cpp
     text.cpp
     uielement.cpp

--- a/ui/button.cpp
+++ b/ui/button.cpp
@@ -17,9 +17,9 @@ void Button::Render() const
     mRectangle.Draw(mPosition);
 }
 
-UIElementType Button::GetType() const
+void Button::Accept(ProcessEventVisitor& uiElement)
 {
-    return UIElementType::Button;
+    uiElement.VisitButton(*this);
 }
 
 void Button::AddListener(ButtonEvent event, std::function<void()> callback)

--- a/ui/button.cpp
+++ b/ui/button.cpp
@@ -19,7 +19,7 @@ void Button::Render() const
 
 void Button::Accept(ProcessEventVisitor& uiElement)
 {
-    uiElement.VisitButton(*this);
+    uiElement.Visit(*this);
 }
 
 void Button::AddListener(ButtonEvent event, std::function<void()> callback)

--- a/ui/button.cpp
+++ b/ui/button.cpp
@@ -59,6 +59,16 @@ void Button::SetPosition(const glm::vec3& position)
     mColliderBox.OnPositionUpdate(position);
 }
 
+float Button::GetWidth() const
+{
+    return mRectangle.GetWidth();
+}
+
+float Button::GetHeight() const
+{
+    return mRectangle.GetHeight();
+}
+
 void Button::Resize(float width, float height)
 {
     mRectangle.Resize(width, height);

--- a/ui/button.h
+++ b/ui/button.h
@@ -30,7 +30,7 @@ public:
     Button(float width, float height);
 
     void Render() const override;
-    UIElementType GetType() const override;
+    void Accept(ProcessEventVisitor& uiElement) override;
 
     void AddListener(ButtonEvent event, std::function<void()> callback);
     void OnEvent(ButtonEvent event);

--- a/ui/button.h
+++ b/ui/button.h
@@ -36,6 +36,8 @@ public:
     void OnEvent(ButtonEvent event);
 
     void SetPosition(const glm::vec3& position) override;
+    float GetWidth() const;
+    float GetHeight() const;
     void Resize(float width, float height);
     ColliderBox* GetColliderBox();
     bool WasPressed() const;

--- a/ui/checkbox.cpp
+++ b/ui/checkbox.cpp
@@ -33,9 +33,9 @@ void CheckBox::Render() const
     }
 }
 
-UIElementType CheckBox::GetType() const
+void CheckBox::Accept(ProcessEventVisitor& visitor)
 {
-    return UIElementType::CheckBox;
+    visitor.VisitCheckBox(*this);
 }
 
 void CheckBox::SetPosition(const glm::vec3& position)

--- a/ui/checkbox.cpp
+++ b/ui/checkbox.cpp
@@ -35,7 +35,7 @@ void CheckBox::Render() const
 
 void CheckBox::Accept(ProcessEventVisitor& visitor)
 {
-    visitor.VisitCheckBox(*this);
+    visitor.Visit(*this);
 }
 
 void CheckBox::SetPosition(const glm::vec3& position)

--- a/ui/checkbox.cpp
+++ b/ui/checkbox.cpp
@@ -1,0 +1,84 @@
+#include "checkbox.h"
+
+namespace pong
+{
+
+constexpr float BORDER_THICKNESS = 10.0f;
+constexpr float BORDER_GAP = 10.0f;
+
+CheckBox::CheckBox(float width, float height, bool defaultValue) :
+    mLines {
+        MeshComponent { width,            BORDER_THICKNESS, glm::vec3(0.0f, height / 2.0f - BORDER_THICKNESS / 2.0f, 0.0f) },
+        MeshComponent { width,            BORDER_THICKNESS, glm::vec3(0.0f, height / -2.0f + BORDER_THICKNESS / 2.0f, 0.0f) },
+        MeshComponent { BORDER_THICKNESS, height,           glm::vec3(width / -2.0f + BORDER_THICKNESS / 2.0f, 0.0f, 0.0f) },
+        MeshComponent { BORDER_THICKNESS, height,           glm::vec3(width / 2.0f - BORDER_THICKNESS / 2.0f, 0.0f, 0.0f) }
+    },
+    mFill { width - (BORDER_THICKNESS + BORDER_GAP) * 2.0f, height - (BORDER_THICKNESS + BORDER_GAP) * 2.0f},
+    mColliderBox{width, height},
+    mValue{defaultValue}
+{
+    mFill.SetEnabled(mValue);
+}
+
+void CheckBox::Render() const
+{
+    for (const auto& line : mLines)
+    {
+        line.mMesh.Draw(line.mPosition);
+    }
+
+    if (mValue)
+    {
+        mFill.Draw(mPosition);
+    }
+}
+
+UIElementType CheckBox::GetType() const
+{
+    return UIElementType::CheckBox;
+}
+
+void CheckBox::SetPosition(const glm::vec3& position)
+{
+    mPosition = position;
+
+    for (auto& line : mLines)
+    {
+        line.mPosition = mPosition + line.mOffset;
+    }
+
+    mColliderBox.OnPositionUpdate(mPosition);
+}
+
+void CheckBox::OnClick()
+{
+    SetValue(!mValue);
+}
+
+void CheckBox::AddValueChangeListener(std::function<void(bool)> callback)
+{
+    mValueChangeListeners.push_back(callback);
+}
+
+void CheckBox::SetValue(bool value)
+{
+    mValue = value;
+    mFill.SetEnabled(mValue);
+
+    for (const auto& callback : mValueChangeListeners)
+    {
+        callback(mValue);
+    }
+}
+
+bool CheckBox::GetValue() const
+{
+    return mValue;
+}
+
+ColliderBox* CheckBox::GetColliderBox()
+{
+    return &mColliderBox;
+}
+
+} // namespace pong

--- a/ui/checkbox.h
+++ b/ui/checkbox.h
@@ -13,8 +13,8 @@ class CheckBox : public UIElement
 public:
     CheckBox(float width, float height, bool defaultValue);
 
-    UIElementType GetType() const override;
     void Render() const override;
+    void Accept(ProcessEventVisitor& visitor) override;
     void SetPosition(const glm::vec3& position) override;
 
     void OnClick();

--- a/ui/checkbox.h
+++ b/ui/checkbox.h
@@ -13,8 +13,8 @@ class CheckBox : public UIElement
 public:
     CheckBox(float width, float height, bool defaultValue);
 
-    void Render() const override;
     UIElementType GetType() const override;
+    void Render() const override;
     void SetPosition(const glm::vec3& position) override;
 
     void OnClick();

--- a/ui/checkbox.h
+++ b/ui/checkbox.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "colliderbox.h"
+#include "rectangle.h"
+#include "slider.h"
+#include "uielement.h"
+
+namespace pong
+{
+
+class CheckBox : public UIElement
+{
+public:
+    CheckBox(float width, float height, bool defaultValue);
+
+    void Render() const override;
+    UIElementType GetType() const override;
+    void SetPosition(const glm::vec3& position) override;
+
+    void OnClick();
+    void AddValueChangeListener(std::function<void(bool)> callback);
+
+    void SetValue(bool value);
+    bool GetValue() const;
+    ColliderBox* GetColliderBox();
+
+private:
+    std::array<MeshComponent, 4> mLines {};
+    Rectangle mFill { 0.0f, 0.0f };
+    ColliderBox mColliderBox { 0.0f, 0.0f };
+    std::vector<std::function<void(bool)>> mValueChangeListeners {};
+    bool mValue { true };
+};
+
+} // namespace pong

--- a/ui/slider.cpp
+++ b/ui/slider.cpp
@@ -54,9 +54,9 @@ void Slider::Render() const
     mHandleMesh.mMesh.Draw(mHandleMesh.mPosition);
 }
 
-UIElementType Slider::GetType() const
+void Slider::Accept(ProcessEventVisitor& visitor)
 {
-    return UIElementType::Slider;
+    visitor.VisitSlider(*this);
 }
 
 void Slider::SetPosition(const glm::vec3& position)

--- a/ui/slider.cpp
+++ b/ui/slider.cpp
@@ -56,7 +56,7 @@ void Slider::Render() const
 
 void Slider::Accept(ProcessEventVisitor& visitor)
 {
-    visitor.VisitSlider(*this);
+    visitor.Visit(*this);
 }
 
 void Slider::SetPosition(const glm::vec3& position)

--- a/ui/slider.cpp
+++ b/ui/slider.cpp
@@ -30,13 +30,13 @@ Slider::Slider(float width, float height, float min, float max, float step, floa
     const float handleHeight = height * HANDLE_HEIGHT_PERCENT;
     const float handleXPos = fillWidth - width / 2.0f;
 
-    mBorderMeshes[0] = { Rectangle(BORDER_THICKNESS, height),   glm::vec3(-verticalBorderXPos, 0.0f, 0.0f),   glm::vec3(-verticalBorderXPos, 0.0f, 0.0f)   };
-    mBorderMeshes[1] = { Rectangle(BORDER_THICKNESS, height),   glm::vec3(verticalBorderXPos, 0.0f, 0.0f),    glm::vec3(verticalBorderXPos, 0.0f, 0.0f)    };
-    mBorderMeshes[2] = { Rectangle(width, BORDER_THICKNESS),    glm::vec3(0.0f, -horizontalBorderYPos, 0.0f), glm::vec3(0.0f, -horizontalBorderYPos, 0.0f) };
-    mBorderMeshes[3] = { Rectangle(width, BORDER_THICKNESS),    glm::vec3(0.0f, horizontalBorderYPos, 0.0f),  glm::vec3(0.0f, horizontalBorderYPos, 0.0f)  };
+    mBorderMeshes[0] = { BORDER_THICKNESS, height,           glm::vec3(-verticalBorderXPos, 0.0f, 0.0f)   };
+    mBorderMeshes[1] = { BORDER_THICKNESS, height,           glm::vec3(verticalBorderXPos, 0.0f, 0.0f)    };
+    mBorderMeshes[2] = { width,            BORDER_THICKNESS, glm::vec3(0.0f, -horizontalBorderYPos, 0.0f) };
+    mBorderMeshes[3] = { width,            BORDER_THICKNESS, glm::vec3(0.0f, horizontalBorderYPos, 0.0f)  };
 
-    mFillMesh   = { Rectangle(fillWidth, fillHeight),     glm::vec3(fillXPos, 0.0f, 0.0f),   glm::vec3(fillXPos, 0.0f, 0.0f)   };
-    mHandleMesh = { Rectangle(handleWidth, handleHeight), glm::vec3(handleXPos, 0.0f, 0.0f), glm::vec3(handleXPos, 0.0f, 0.0f) };
+    mFillMesh   = { fillWidth,   fillHeight,   glm::vec3(fillXPos, 0.0f, 0.0f)   };
+    mHandleMesh = { handleWidth, handleHeight, glm::vec3(handleXPos, 0.0f, 0.0f) };
 
     mColliderBox = ColliderBox(width, height);
 }

--- a/ui/slider.cpp
+++ b/ui/slider.cpp
@@ -21,19 +21,21 @@ Slider::Slider(float width, float height, float min, float max, float step, floa
     ASSERT(min < max && step > 0.0f);
     const float verticalBorderXPos = width / 2.0f - BORDER_THICKNESS / 2.0f;
     const float horizontalBorderYPos = height / 2.0f - BORDER_THICKNESS / 2.0f;
-    const float fillHeight = height - (BORDER_GAP + BORDER_THICKNESS) * 2.0f;
-    const float fillWidth = width * (mValue - mMin) / (mMax - mMin) - (BORDER_GAP + BORDER_THICKNESS);
-    const float startXPos = BORDER_GAP + BORDER_THICKNESS;
-    const float endXPos = width + BORDER_GAP + BORDER_THICKNESS;
-    const float fillXPos = fillWidth / -2.0f - (1.0f - mValue / (mMax - mMin) - 0.5f) * (endXPos - startXPos);
-    const float handleWidth = height * HANDLE_WIDTH_PERCENT;
-    const float handleHeight = height * HANDLE_HEIGHT_PERCENT;
-    const float handleXPos = fillWidth - width / 2.0f;
 
     mBorderMeshes[0] = { BORDER_THICKNESS, height,           glm::vec3(-verticalBorderXPos, 0.0f, 0.0f)   };
     mBorderMeshes[1] = { BORDER_THICKNESS, height,           glm::vec3(verticalBorderXPos, 0.0f, 0.0f)    };
     mBorderMeshes[2] = { width,            BORDER_THICKNESS, glm::vec3(0.0f, -horizontalBorderYPos, 0.0f) };
     mBorderMeshes[3] = { width,            BORDER_THICKNESS, glm::vec3(0.0f, horizontalBorderYPos, 0.0f)  };
+
+    const float startXPos = BORDER_GAP + BORDER_THICKNESS;
+    const float endXPos = width + startXPos;
+    const float fillHeight = height - (BORDER_GAP + BORDER_THICKNESS) * 2.0f;
+    const float fillWidth = width * std::fabs(mValue - mMin) / (mMax - mMin) - startXPos;
+    const float percentValue = std::fabs(mValue - mMin) / (mMax - mMin);
+    const float fillXPos = fillWidth / -2.0f - (1.0f - percentValue - 0.5f) * (endXPos - startXPos);
+    const float handleWidth = height * HANDLE_WIDTH_PERCENT;
+    const float handleHeight = height * HANDLE_HEIGHT_PERCENT;
+    const float handleXPos = fillWidth - width / 2.0f;
 
     mFillMesh   = { fillWidth,   fillHeight,   glm::vec3(fillXPos, 0.0f, 0.0f)   };
     mHandleMesh = { handleWidth, handleHeight, glm::vec3(handleXPos, 0.0f, 0.0f) };
@@ -43,9 +45,9 @@ Slider::Slider(float width, float height, float min, float max, float step, floa
 
 void Slider::Render() const
 {
-    for (const auto& sliderMesh : mBorderMeshes)
+    for (const auto& borderMesh : mBorderMeshes)
     {
-        sliderMesh.mMesh.Draw(sliderMesh.mPosition);
+        borderMesh.mMesh.Draw(borderMesh.mPosition);
     }
 
     mFillMesh.mMesh.Draw(mFillMesh.mPosition);
@@ -60,9 +62,9 @@ UIElementType Slider::GetType() const
 void Slider::SetPosition(const glm::vec3& position)
 {
     mPosition = position;
-    for (auto& sliderMesh : mBorderMeshes)
+    for (auto& borderMesh : mBorderMeshes)
     {
-        sliderMesh.mPosition = mPosition + sliderMesh.mOffset;
+        borderMesh.mPosition = mPosition + borderMesh.mOffset;
     }
 
     mFillMesh.mPosition = mPosition + mFillMesh.mOffset;
@@ -70,7 +72,7 @@ void Slider::SetPosition(const glm::vec3& position)
     mColliderBox.OnPositionUpdate(mPosition);
 }
 
-void Slider::OnMouseHeld(const glm::vec3& mousePosition)
+void Slider::OnMouseDown(const glm::vec3& mousePosition)
 {
     mWasPressed = true;
 

--- a/ui/slider.cpp
+++ b/ui/slider.cpp
@@ -97,6 +97,11 @@ void Slider::OnMouseHeld(const glm::vec3& mousePosition)
     const float newHandleXOffset = (stepPercent - 0.5f) * (maxX - minX);
     mHandleMesh.mOffset.x = newHandleXOffset;
     mHandleMesh.mPosition.x = mPosition.x + mHandleMesh.mOffset.x;
+
+    for (const auto& listener : mValueChangeListeners)
+    {
+        listener(mValue);
+    }
 }
 
 void Slider::OnMouseReleased()

--- a/ui/slider.cpp
+++ b/ui/slider.cpp
@@ -1,0 +1,123 @@
+#include "slider.h"
+
+#include <algorithm>
+
+namespace pong
+{
+
+Slider::Slider(float width, float height, float min, float max, float step, float startValue) :
+    mWidth(width),
+    mHeight(height),
+    mMin(min),
+    mMax(max),
+    mStep(step),
+    mValue(std::clamp(startValue, min, max))
+{
+    ASSERT(min < max && step > 0.0f);
+    const float borderThickness = height * 0.05f;
+    const float verticalBorderXPos = width / 2.0f - borderThickness / 2.0f;
+    const float horizontalBorderYPos = height / 2.0f - borderThickness / 2.0f;
+    const float fillHeight = height * 0.75f;
+    const float fillWidth = width * (mValue - mMin) / (mMax - mMin) * 0.9f;
+    const float fillXPos = fillWidth / -2.0f;
+    const float handleWidth = height * 1.1f;
+    const float handleHeight = handleWidth;
+    const float handleXPos = fillWidth - width / 2.0f;
+
+    mSliderMeshes[0] = { Rectangle(borderThickness, height),   glm::vec3(-verticalBorderXPos, 0.0f, 0.0f),   glm::vec3(-verticalBorderXPos, 0.0f, 0.0f)   }; // Border
+    mSliderMeshes[1] = { Rectangle(borderThickness, height),   glm::vec3(verticalBorderXPos, 0.0f, 0.0f),    glm::vec3(verticalBorderXPos, 0.0f, 0.0f)    }; // Border
+    mSliderMeshes[2] = { Rectangle(width, borderThickness),    glm::vec3(0.0f, -horizontalBorderYPos, 0.0f), glm::vec3(0.0f, -horizontalBorderYPos, 0.0f) }; // Border
+    mSliderMeshes[3] = { Rectangle(width, borderThickness),    glm::vec3(0.0f, horizontalBorderYPos, 0.0f),  glm::vec3(0.0f, horizontalBorderYPos, 0.0f)  }; // Border
+    mSliderMeshes[4] = { Rectangle(fillWidth, fillHeight),     glm::vec3(fillXPos, 0.0f, 0.0f),              glm::vec3(0.0f) }; // Fill
+    mSliderMeshes[5] = { Rectangle(handleWidth, handleHeight), glm::vec3(handleXPos, 0.0f, 0.0f),            glm::vec3(0.0f) }; // Handle
+
+    mHandleColliderBox = ColliderBox(width, height);
+}
+
+void Slider::Render() const
+{
+    for (const auto& sliderMesh : mSliderMeshes)
+    {
+        sliderMesh.mMesh.Draw(sliderMesh.mPosition);
+    }
+}
+
+UIElementType Slider::GetType() const
+{
+    return UIElementType::Slider;
+}
+
+void Slider::SetPosition(const glm::vec3& position)
+{
+    mPosition = position;
+    for (auto& sliderMesh : mSliderMeshes)
+    {
+        sliderMesh.mPosition = mPosition + sliderMesh.mOffset;
+    }
+
+    mHandleColliderBox.OnPositionUpdate(mSliderMeshes[5].mPosition);
+}
+
+void Slider::OnMouseHeld(glm::vec3 mousePosition)
+{
+    mWasPressed = true;
+
+    const int steps = static_cast<int>((mMax - mMin) / mStep) + 1;
+    const float minX = mPosition.x - (mWidth * 0.9f) / 2.0f;
+    const float maxX = mPosition.x + (mWidth * 0.9f) / 2.0f;
+    const float currentX = mousePosition.x - minX;
+    const float stepSize = (maxX - minX) / (steps - 1);
+    const float percent = currentX / (maxX - minX);
+    const float percentPerStep = 1.0f / (steps - 1);
+    const int stepsIn = static_cast<int>(std::roundf(percent / percentPerStep));
+    float lastStepPercent = 0;
+    float stepPercent = percentPerStep;
+    // print out all variables
+    std::cout << "mousePosition.x: " << mousePosition.x << ", mousePosition.y: " << mousePosition.y << std::endl;
+    std::cout << "mPosition.x: " << mPosition.x << ", mPosition.y: " << mPosition.y << std::endl;
+    std::cout << "MinX: " << minX << ", MaxX: " << maxX << ", CurrentX: " << currentX << ", StepSize: " << stepSize << std::endl;
+    std::cout << "Percent: " << percent << std::endl;
+    while (!(lastStepPercent < percent && percent < stepPercent))
+    {
+        lastStepPercent = stepPercent;
+        stepPercent += percentPerStep;
+    }
+    // round to nearest step
+    float roundedPercent = (percent - lastStepPercent) < (stepPercent - percent) ? lastStepPercent : stepPercent;
+    std::cout << "Percent lower: " << lastStepPercent << ", upper: " << stepPercent << std::endl;
+    std::cout << "Rounded percent: " << roundedPercent << std::endl;
+    const float value = roundedPercent * (mMax - mMin) + mMin;
+    std::cout << "Value: " << value << std::endl;
+    roundedPercent -= 0.5f;
+    const float newHandleXOffset = roundedPercent * (maxX - minX);
+    mSliderMeshes[5].mOffset.x = newHandleXOffset;
+    mSliderMeshes[5].mPosition.x = mPosition.x + mSliderMeshes[5].mOffset.x;
+    //mSliderMeshes[5].mPosition.x = std::clamp(mSliderMeshes[5].mPosition.x, );
+}
+
+void Slider::OnMouseReleased()
+{
+    mWasPressed = false;
+}
+
+void Slider::AddValueChangeListener(std::function<void(float)> listener)
+{
+    mValueChangeListeners.push_back(listener);
+}
+
+bool Slider::WasPressed() const
+{
+    return mWasPressed;
+}
+
+ColliderBox* Slider::GetColliderBox()
+{
+    return &mHandleColliderBox;
+}
+
+float Slider::GetValue() const
+{
+    return mValue;
+}
+
+} // namespace pong

--- a/ui/slider.h
+++ b/ui/slider.h
@@ -17,8 +17,8 @@ public:
     Slider(float width, float height, float min, float max, float step, float startValue);
     ~Slider() = default;
 
-    UIElementType GetType() const override;
     void Render() const override;
+    void Accept(ProcessEventVisitor& visitor) override;
     void SetPosition(const glm::vec3& position) override;
 
     void OnMouseDown(const glm::vec3& mousePosition);

--- a/ui/slider.h
+++ b/ui/slider.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "colliderbox.h"
+#include "rectangle.h"
+#include "uielement.h"
+
+#include <array>
+#include <functional>
+#include <vector>
+
+namespace pong
+{
+
+struct SliderMesh
+{
+    Rectangle mMesh { 0.0f, 0.0f };
+    glm::vec3 mOffset { 0.0f };
+    glm::vec3 mPosition { 0.0f };
+};
+
+class Slider : public UIElement
+{
+public:
+    Slider(float width, float height, float min, float max, float step, float startValue);
+    ~Slider() = default;
+
+    void Render() const override;
+    UIElementType GetType() const override;
+    void SetPosition(const glm::vec3& position) override;
+
+    void OnMouseHeld(glm::vec3 mousePosition);
+    void OnMouseReleased();
+    void AddValueChangeListener(std::function<void(float)> listener);
+
+    bool WasPressed() const;
+    ColliderBox* GetColliderBox();
+    float GetValue() const;
+
+private:
+    // Represents the slider background, the slider handle, and the slider fill
+    std::array<SliderMesh, 6> mSliderMeshes {};
+    ColliderBox mHandleColliderBox { 0.0f, 0.0f };
+    std::vector<std::function<void(float)>> mValueChangeListeners {};
+    float mWidth { 0.0f };
+    float mHeight { 0.0f };
+    float mMin { 0.0f };
+    float mMax { 0.0f };
+    float mStep { 0.0f };
+    float mValue { 0.0f };
+    bool mWasPressed { false };
+};
+
+} // namespace pong

--- a/ui/slider.h
+++ b/ui/slider.h
@@ -11,14 +11,6 @@
 namespace pong
 {
 
-// Slider is built from multiple meshes each with an offset from the slider's position/origin
-struct SliderMesh
-{
-    Rectangle mMesh { 0.0f, 0.0f };
-    glm::vec3 mOffset { 0.0f };
-    glm::vec3 mPosition { 0.0f };
-};
-
 class Slider : public UIElement
 {
 public:
@@ -39,9 +31,9 @@ public:
 
 private:
     // Represents the slider background, the slider handle, and the slider fill
-    std::array<SliderMesh, 4> mBorderMeshes {};
-    SliderMesh mFillMesh {};
-    SliderMesh mHandleMesh {};
+    std::array<MeshComponent, 4> mBorderMeshes {};
+    MeshComponent mFillMesh {};
+    MeshComponent mHandleMesh {};
     ColliderBox mColliderBox { 0.0f, 0.0f };
     std::vector<std::function<void(float)>> mValueChangeListeners {};
     float mWidth { 0.0f };

--- a/ui/slider.h
+++ b/ui/slider.h
@@ -11,6 +11,7 @@
 namespace pong
 {
 
+// Slider is built from multiple meshes each with an offset from the slider's position/origin
 struct SliderMesh
 {
     Rectangle mMesh { 0.0f, 0.0f };
@@ -28,7 +29,7 @@ public:
     UIElementType GetType() const override;
     void SetPosition(const glm::vec3& position) override;
 
-    void OnMouseHeld(glm::vec3 mousePosition);
+    void OnMouseHeld(const glm::vec3& mousePosition);
     void OnMouseReleased();
     void AddValueChangeListener(std::function<void(float)> listener);
 
@@ -38,8 +39,10 @@ public:
 
 private:
     // Represents the slider background, the slider handle, and the slider fill
-    std::array<SliderMesh, 6> mSliderMeshes {};
-    ColliderBox mHandleColliderBox { 0.0f, 0.0f };
+    std::array<SliderMesh, 4> mBorderMeshes {};
+    SliderMesh mFillMesh {};
+    SliderMesh mHandleMesh {};
+    ColliderBox mColliderBox { 0.0f, 0.0f };
     std::vector<std::function<void(float)>> mValueChangeListeners {};
     float mWidth { 0.0f };
     float mHeight { 0.0f };

--- a/ui/slider.h
+++ b/ui/slider.h
@@ -17,11 +17,11 @@ public:
     Slider(float width, float height, float min, float max, float step, float startValue);
     ~Slider() = default;
 
-    void Render() const override;
     UIElementType GetType() const override;
+    void Render() const override;
     void SetPosition(const glm::vec3& position) override;
 
-    void OnMouseHeld(const glm::vec3& mousePosition);
+    void OnMouseDown(const glm::vec3& mousePosition);
     void OnMouseReleased();
     void AddValueChangeListener(std::function<void(float)> listener);
 

--- a/ui/text.cpp
+++ b/ui/text.cpp
@@ -178,7 +178,7 @@ void Text::Render() const
 
 void Text::Accept(ProcessEventVisitor& visitor)
 {
-    visitor.VisitText(*this);
+    visitor.Visit(*this);
 }
 
 } // namespace pong

--- a/ui/text.cpp
+++ b/ui/text.cpp
@@ -176,9 +176,9 @@ void Text::Render() const
     }
 }
 
-UIElementType Text::GetType() const
+void Text::Accept(ProcessEventVisitor& visitor)
 {
-    return UIElementType::Text;
+    visitor.VisitText(*this);
 }
 
 } // namespace pong

--- a/ui/text.h
+++ b/ui/text.h
@@ -21,7 +21,7 @@ public:
     void SetColor(GLRGBAColor color);
 
     void Render() const override;
-    UIElementType GetType() const override;
+    void Accept(ProcessEventVisitor& visitor) override;
 
 private:
     void CreateText();

--- a/ui/uielement.h
+++ b/ui/uielement.h
@@ -2,6 +2,7 @@
 
 #include "colliderbox.h"
 #include "rectangle.h"
+#include "processeventvisitor.h"
 
 #include <glm/glm.hpp>
 
@@ -27,20 +28,12 @@ public:
     }
 };
 
-enum class UIElementType
-{
-    Button,
-    CheckBox,
-    Slider,
-    Text
-};
-
 class UIElement
 {
 public:
     virtual ~UIElement() = default;
     virtual void Render() const = 0;
-    virtual UIElementType GetType() const = 0;
+    virtual void Accept(ProcessEventVisitor& visitor) = 0;
 
     int GetOrderLayer() const;
     void SetOrderLayer(int orderLayer);

--- a/ui/uielement.h
+++ b/ui/uielement.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "colliderbox.h"
-#include "mesh.h"
+#include "rectangle.h"
 
 #include <glm/glm.hpp>
 
@@ -10,9 +10,27 @@
 namespace pong
 {
 
+// Uses to build complex meshes using multiple meshes, with offsets from origin
+struct MeshComponent
+{
+public:
+    Rectangle mMesh { 0.0f, 0.0f };
+    glm::vec3 mOffset { 0.0f };
+    glm::vec3 mPosition { 0.0f };
+
+    MeshComponent() = default;
+    MeshComponent(float width, float height, const glm::vec3& offset) :
+        mMesh{width, height},
+        mOffset{offset},
+        mPosition(mOffset)
+    {
+    }
+};
+
 enum class UIElementType
 {
     Button,
+    CheckBox,
     Slider,
     Text
 };

--- a/ui/uielement.h
+++ b/ui/uielement.h
@@ -13,6 +13,7 @@ namespace pong
 enum class UIElementType
 {
     Button,
+    Slider,
     Text
 };
 


### PR DESCRIPTION
Pretty similar to the last PR, the new ui elements of the slider and checkbox allow to get some user input in a nice form. This lays out the settings page to tweak volume settings, difficulty and likely some more settings such as resolution in the future.

A couple other changes to note:
- Input class is changed to be able to distinguish between inputs being held, and first being pressed. This is so buttons and ui elements only trigger when hovering over them and the frame they were pressed.
-- Pressed - Frame the input was pushed down,
-- Held - Any frames after pressed when the input is still down
-- Released - Frame the input was released
-- NotPressed - Any frames after released when the input is still up
- Settings screen and title screen inherit from a UIMenu class. This is just for setting up similar animations for the buttons and text combos on both screens
- Both slider and checkbox use a MeshComponent to build a simple border around the ui element. This consists of 4 Rectangle meshes to layout the border.