### PR TITLE
Create font strings on intialization instead of during runtime

### DIFF
--- a/assets/game.scene
+++ b/assets/game.scene
@@ -167,7 +167,7 @@
         {
           "type": "Text",
           "text": "0",
-          "scale": 2.0
+          "scale": 1.0
         }
       ]
     },
@@ -182,7 +182,7 @@
         {
           "type": "Text",
           "text": "0",
-          "scale": 2.0
+          "scale": 1.0
         }
       ]
     },

--- a/assets/settings.scene
+++ b/assets/settings.scene
@@ -20,8 +20,7 @@
         {
           "type": "Text",
           "text": "Settings",
-          "scale": 1.5,
-          "pixel_height": 256
+          "scale": 1.5
         }
       ]
     },
@@ -41,6 +40,7 @@
         {
           "type": "Text",
           "text": "Back",
+          "scale": 0.45,
           "order_layer": 1,
           "color": {
             "r": 0,
@@ -62,7 +62,7 @@
         {
           "type": "Text",
           "text": "Target FPS: -1",
-          "scale": 0.75,
+          "scale": 0.4,
           "order_layer": 1
         }
       ]
@@ -97,7 +97,7 @@
         {
           "type": "Text",
           "text": "Vsync",
-          "scale": 0.75,
+          "scale": 0.4,
           "order_layer": 1
         }
       ]
@@ -129,7 +129,7 @@
         {
           "type": "Text",
           "text": "SpatialAudio",
-          "scale": 0.75,
+          "scale": 0.4,
           "order_layer": 1
         }
       ]
@@ -161,7 +161,7 @@
         {
           "type": "Text",
           "text": "Difficulty",
-          "scale": 0.75,
+          "scale": 0.4,
           "order_layer": 1
         }
       ]
@@ -177,7 +177,7 @@
         {
           "type": "Text",
           "text": "Easy",
-          "scale": 0.75,
+          "scale": 0.4,
           "order_layer": 1
         }
       ]
@@ -209,7 +209,7 @@
         {
           "type": "Text",
           "text": "Medium",
-          "scale": 0.75,
+          "scale": 0.4,
           "order_layer": 1
         }
       ]
@@ -241,7 +241,7 @@
         {
           "type": "Text",
           "text": "Hard",
-          "scale": 0.75,
+          "scale": 0.4,
           "order_layer": 1
         }
       ]
@@ -273,7 +273,7 @@
         {
           "type": "Text",
           "text": "Insane",
-          "scale": 0.75,
+          "scale": 0.4,
           "order_layer": 1
         }
       ]
@@ -305,7 +305,7 @@
         {
           "type": "Text",
           "text": "Volume: -1",
-          "scale": 0.75,
+          "scale": 0.4,
           "order_layer": 1
         }
       ]

--- a/assets/title.scene
+++ b/assets/title.scene
@@ -20,8 +20,7 @@
         {
           "type": "Text",
           "text": "Pong",
-          "scale": 1.5,
-          "pixel_height": 256
+          "scale": 2.0
         }
       ]
     },
@@ -41,7 +40,7 @@
         {
           "type": "Text",
           "text": "Play",
-          "scale": 0.75,
+          "scale": 0.65,
           "order_layer": 1,
           "color": {
             "r": 0.0,
@@ -68,7 +67,7 @@
         {
           "type": "Text",
           "text": "Settings",
-          "scale": 0.5,
+          "scale": 0.4,
           "order_layer": 1,
           "color": {
             "r": 0.0,
@@ -95,7 +94,7 @@
         {
           "type": "Text",
           "text": "Quit",
-          "scale": 0.75,
+          "scale": 0.65,
           "order_layer": 1,
           "color": {
             "r": 0.0,

--- a/assets/title.scene
+++ b/assets/title.scene
@@ -41,6 +41,7 @@
         {
           "type": "Text",
           "text": "Play",
+          "scale": 0.75,
           "order_layer": 1,
           "color": {
             "r": 0.0,
@@ -67,7 +68,7 @@
         {
           "type": "Text",
           "text": "Settings",
-          "scale": 0.75,
+          "scale": 0.5,
           "order_layer": 1,
           "color": {
             "r": 0.0,
@@ -94,6 +95,7 @@
         {
           "type": "Text",
           "text": "Quit",
+          "scale": 0.75,
           "order_layer": 1,
           "color": {
             "r": 0.0,

--- a/components/text.cpp
+++ b/components/text.cpp
@@ -1,26 +1,27 @@
 #include "text.h"
 
 #include "config.h"
+#include "font.h"
 #include "logger.h"
-
-#define STB_TRUETYPE_IMPLEMENTATION
-#include <stb_truetype.h>
+#include "pong.h"
 
 #include <fstream>
 
 namespace pong
 {
 
-Text::Text()
+Text::Text() :
+    mText { "" },
+    mFont { Pong::GetInstance().GetFontBank().GetDefaultFontName() },
+    mScale { 1.0f }
 {
-    Text("Default", "D:/code/pong/assets/pixeloid.ttf", 1.0f, 128);
+    RecomputeText();
 }
 
-Text::Text(const std::string& text, const std::string& path, float scale, int pixelLineHeight) :
+Text::Text(const std::string& text, const std::string& fontName, float scale) :
     mText { text },
-    mFontPath { path },
-    mScale { scale },
-    mPixelLineHeight { pixelLineHeight }
+    mFont { fontName },
+    mScale { scale }
 {
     RecomputeText();
 }
@@ -44,125 +45,33 @@ BaseComponent* Text::GetBaseComponent()
 
 void Text::RecomputeText()
 {
-    std::ifstream file(mFontPath, std::ios::binary);
-    if (!file)
+    Font* font = Pong::GetInstance().GetFontBank().GetFont(mFont);
+    if (font == nullptr)
     {
-        RealTimeLogError("Failed to open true type font file: {}", mFontPath);
+        RealTimeLogError("Failed to load font: {}", mFont);
         ASSERT(false);
         return;
     }
 
-    std::vector<unsigned char> fontData((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    const FontString fontString = font->GetCharacters(mText);
+    const std::vector<FontCharacter>& fontCharacters = fontString.mFontCharacters;
 
-    stbtt_fontinfo font;
-    stbtt_InitFont(&font, fontData.data(), 0);
-
-    const float pixelScale = stbtt_ScaleForPixelHeight(&font, static_cast<float>(mPixelLineHeight));
-
-    float totalTextWidth = 0.0f;
-    float totalTextHeight = 0.0f;
-    float currentLineWidth = 0.0f;
-    float currentLineHeight = 0.0f;
-
-    int unscaledAscent, unscaledDescent, unscaledLineGap;
-    stbtt_GetFontVMetrics(&font, &unscaledAscent, &unscaledDescent, &unscaledLineGap);
-
-    const float ascent  = unscaledAscent  * pixelScale;
-    const float descent = unscaledDescent * pixelScale;
-    const float lineGap = unscaledLineGap * pixelScale;
-
-    float currentX = 0;
-    float currentY = 0;
-
-    for (int i = 0; i < mText.length(); i++)
+    for (const FontCharacter& character : fontCharacters)
     {
-        const char character = mText[i];
-
-        int unscaledGlpyhWidth = 0;
-	    int unscaledLeftSideBearing = 0;
-        stbtt_GetCodepointHMetrics(&font, character, &unscaledGlpyhWidth, &unscaledLeftSideBearing);
-
-        const float glpyhWidth = unscaledGlpyhWidth * pixelScale * mScale;
-        const float leftSideBearing = unscaledLeftSideBearing * pixelScale * mScale;
-
-        int xCoord1 = 0;
-        int yCoord1 = 0;
-        int xCoord2 = 0;
-        int yCoord2 = 0;
-        stbtt_GetCodepointBitmapBox(&font, character, pixelScale, pixelScale, &xCoord1, &yCoord1, &xCoord2, &yCoord2);
-
-        const int charWidth  = xCoord2 - xCoord1;
-        const int charHeight = yCoord2 - yCoord1;
-
-        auto alphaTexture = std::vector<unsigned char>();
-        alphaTexture.resize(charWidth * charHeight);
-
-        if (character == '\n')
-        {
-            currentY -= (ascent - descent + lineGap) * mScale;
-            currentX = 0;
-
-            if (currentLineWidth > totalTextWidth)
-            {
-                totalTextWidth = currentLineWidth;
-            }
-            totalTextHeight = fabs(currentY);
-            currentLineWidth = 0;
-            currentLineHeight = 0;
-        }
-        else
-        {
-            const float spaceAboveCharPixels = ascent + yCoord1;
-            const float characterYOffset = currentY - spaceAboveCharPixels * mScale;
-
-            const float quadScreenWidth  = charWidth * mScale;
-            const float quadScreenHeight = charHeight * mScale;
-
-            const float lineHeight = fabs(characterYOffset - quadScreenHeight);
-            if (lineHeight > currentLineHeight)
-            {
-                currentLineHeight = lineHeight;
-            }
-            currentLineWidth = quadScreenWidth;
-
-            // Since this uses a single character for each texture, stride is just the pixel width of the character
-            const int kStride = charWidth;
-            stbtt_MakeCodepointBitmap(&font, alphaTexture.data(), charWidth, charHeight, kStride, pixelScale, pixelScale, character);
-
-            if (i > 0)
-            {
-                currentX += leftSideBearing;
-            }
-
-            // Since the current offset is the top left, offset it to center of quad
-            const float finalXOffset = currentX + quadScreenWidth / 2.0f;
-            const float finalYOffset = characterYOffset - quadScreenHeight / 2.0f;
-
-            mCharacters.emplace_back(alphaTexture, quadScreenWidth, quadScreenHeight,
-                                     glm::vec3(finalXOffset, finalYOffset, 0.0f),
-                                     charWidth, charHeight);
-
-            currentX += glpyhWidth;
-
-            // TODO: Needs to also be checked after a \n character
-            if (i == mText.length() - 1)
-            {
-                currentX -= glpyhWidth - quadScreenWidth;
-            }
-        }
-
-        const int kern = stbtt_GetCodepointKernAdvance(&font, character, mText[i + 1]);
-        currentX += fabs(kern * mScale * pixelScale);
-        currentLineWidth = currentX;
+        const float quadWidth = character.mBitmapWidth * mScale;
+        const float quadHeight = character.mBitmapHeight * mScale;
+        const float xOffset = character.mXOffset * mScale;
+        const float yOffset = character.mYOffset * mScale;
+        mCharacters.emplace_back(character.mBitmap, quadWidth, quadHeight,
+                                 glm::vec3(xOffset, -yOffset, 0.0f),
+                                 character.mBitmapWidth, character.mBitmapHeight);
     }
 
-    if (currentLineWidth > totalTextWidth)
-    {
-        totalTextWidth = currentLineWidth;
-    }
-    totalTextHeight += currentLineHeight;
+    const float totalTextWidth = fontString.mWidth * mScale;
+    const float totalTextHeight = fontString.mHeight * mScale;
 
-    // Characters have been created with their top left corner at the origin, so offset them to the center
+    // Characters have been created with their top left corner at the origin,
+    // so offset them to the center of the whole text
     const glm::vec3 center = glm::vec3(totalTextWidth / 2.0f, -totalTextHeight / 2.0f, 0.0f);
     for (auto& character : mCharacters)
     {
@@ -184,16 +93,16 @@ void Text::SetText(const std::string& text)
     RecomputeText();
 }
 
-void Text::SetScale(float scale)
+void Text::SetFont(const std::string& fontName)
 {
-    mScale = scale;
+    mFont = fontName;
     mCharacters.clear();
     RecomputeText();
 }
 
-void Text::SetPixelLineHeight(int pixelLineHeight)
+void Text::SetScale(float scale)
 {
-    mPixelLineHeight = pixelLineHeight;
+    mScale = scale;
     mCharacters.clear();
     RecomputeText();
 }

--- a/components/text.cpp
+++ b/components/text.cpp
@@ -58,13 +58,12 @@ void Text::RecomputeText()
 
     for (const FontCharacter& character : fontCharacters)
     {
-        const float quadWidth = character.mBitmapWidth * mScale;
-        const float quadHeight = character.mBitmapHeight * mScale;
+        const float quadWidth = character.mBitmap.mWidth * mScale;
+        const float quadHeight = character.mBitmap.mHeight * mScale;
         const float xOffset = character.mXOffset * mScale;
         const float yOffset = character.mYOffset * mScale;
-        mCharacters.emplace_back(character.mBitmap, quadWidth, quadHeight,
-                                 glm::vec3(xOffset, -yOffset, 0.0f),
-                                 character.mBitmapWidth, character.mBitmapHeight);
+        mCharacters.emplace_back(character.mBitmap, glm::vec3(xOffset, -yOffset, 0.0f),
+                                 quadWidth, quadHeight);
     }
 
     const float totalTextWidth = fontString.mWidth * mScale;

--- a/components/text.cpp
+++ b/components/text.cpp
@@ -48,7 +48,7 @@ void Text::RecomputeText()
     Font* font = Pong::GetInstance().GetFontBank().GetFont(mFont);
     if (font == nullptr)
     {
-        RealTimeLogError("Failed to load font: {}", mFont);
+        RealTimeLogError("Failed to find font: {}", mFont);
         ASSERT(false);
         return;
     }

--- a/components/text.cpp
+++ b/components/text.cpp
@@ -10,17 +10,9 @@
 namespace pong
 {
 
-Text::Text() :
-    mText { "" },
-    mFont { Pong::GetInstance().GetFontBank().GetDefaultFontName() },
-    mScale { 1.0f }
-{
-    RecomputeText();
-}
-
-Text::Text(const std::string& text, const std::string& fontName, float scale) :
+Text::Text(const std::string& text, Font* font, float scale) :
     mText { text },
-    mFont { fontName },
+    mFont { font },
     mScale { scale }
 {
     RecomputeText();
@@ -45,15 +37,9 @@ BaseComponent* Text::GetBaseComponent()
 
 void Text::RecomputeText()
 {
-    Font* font = Pong::GetInstance().GetFontBank().GetFont(mFont);
-    if (font == nullptr)
-    {
-        RealTimeLogError("Failed to find font: {}", mFont);
-        ASSERT(false);
-        return;
-    }
+    ASSERT(mFont != nullptr);
 
-    const FontString fontString = font->GetCharacters(mText);
+    const FontString fontString = mFont->GetCharacters(mText);
     const std::vector<FontCharacter>& fontCharacters = fontString.mFontCharacters;
 
     for (const FontCharacter& character : fontCharacters)
@@ -92,9 +78,9 @@ void Text::SetText(const std::string& text)
     RecomputeText();
 }
 
-void Text::SetFont(const std::string& fontName)
+void Text::SetFont(Font* font)
 {
-    mFont = fontName;
+    mFont = font;
     mCharacters.clear();
     RecomputeText();
 }

--- a/components/text.h
+++ b/components/text.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "component.h"
+#include "font.h"
 #include "textcharacter.h"
 #include "uicomponent.h"
 
@@ -15,26 +16,25 @@ namespace pong
 class Text : public UIComponent, public Component<Text>
 {
 public:
-    Text();
-    Text(const std::string& text, const std::string& fontName, float scale);
+    Text() = default;
+    Text(const std::string& text, Font* font, float scale);
 
     std::vector<OffsetGraphic> GetRenderables() override;
     BaseComponent* GetBaseComponent() override;
 
     std::string GetText() const;
     void SetText(const std::string& text);
-    void SetFont(const std::string& fontName);
+    void SetFont(Font* font);
     void SetScale(float scale);
     void SetColor(GLRGBAColor color);
     void RecomputeText();
 
     std::string mText {};
-    std::string mFont {};
+    Font* mFont { nullptr };
     float mScale { 1.0f };
 
 private:
     std::vector<TextCharacter> mCharacters {};
-    std::string mFontPath {};
     GLRGBAColor mColor { GLRGBA_WHITE };
 };
 

--- a/components/text.h
+++ b/components/text.h
@@ -16,25 +16,25 @@ class Text : public UIComponent, public Component<Text>
 {
 public:
     Text();
-    Text(const std::string&, const std::string& path, float scale, int pixelLineHeight = 128);
+    Text(const std::string& text, const std::string& fontName, float scale);
 
     std::vector<OffsetGraphic> GetRenderables() override;
     BaseComponent* GetBaseComponent() override;
 
     std::string GetText() const;
     void SetText(const std::string& text);
+    void SetFont(const std::string& fontName);
     void SetScale(float scale);
-    void SetPixelLineHeight(int pixelLineHeight);
     void SetColor(GLRGBAColor color);
     void RecomputeText();
 
-    std::string mText { "" };
+    std::string mText {};
+    std::string mFont {};
     float mScale { 1.0f };
-    int mPixelLineHeight { 128 };
 
 private:
     std::vector<TextCharacter> mCharacters {};
-    std::string mFontPath { "D:/code/pong/assets/pixeloid.ttf" };
+    std::string mFontPath {};
     GLRGBAColor mColor { GLRGBA_WHITE };
 };
 

--- a/engine/graphics/CMakeLists.txt
+++ b/engine/graphics/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(SOURCES
     circle.cpp
+    font.cpp
+    fontbank.cpp
+    image.cpp
     rectangle.cpp
     textcharacter.cpp
 )
@@ -11,6 +14,7 @@ target_link_libraries(graphics
         compile_flags
         engine
         render
+        stb
 )
 
 target_include_directories(graphics

--- a/engine/graphics/font.cpp
+++ b/engine/graphics/font.cpp
@@ -29,14 +29,13 @@ bool Font::LoadFont(const std::string& fontName, const std::string& fontPath)
         return false;
     }
 
-    mFontInfo = new stbtt_fontinfo();
     mFontData = std::vector<unsigned char>(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
-    ASSERT(stbtt_InitFont(mFontInfo, mFontData.data(), 0) != 0);
+    ASSERT(stbtt_InitFont(&mFontInfo, mFontData.data(), 0) != 0);
 
-    mPixelScale = stbtt_ScaleForPixelHeight(mFontInfo, static_cast<float>(PIXEL_LINE_HEIGHT));
+    mPixelScale = stbtt_ScaleForPixelHeight(&mFontInfo, static_cast<float>(PIXEL_LINE_HEIGHT));
 
     int unscaledAscent, unscaledDescent, unscaledLineGap;
-    stbtt_GetFontVMetrics(mFontInfo, &unscaledAscent, &unscaledDescent, &unscaledLineGap);
+    stbtt_GetFontVMetrics(&mFontInfo, &unscaledAscent, &unscaledDescent, &unscaledLineGap);
 
     mAscent  = unscaledAscent  * mPixelScale;
     mDescent = unscaledDescent * mPixelScale;
@@ -56,7 +55,7 @@ FontCharacter Font::LoadCharacter(const char character)
 
     int unscaledGlpyhWidth = 0;
     int unscaledLeftSideBearing = 0;
-    stbtt_GetCodepointHMetrics(mFontInfo, character, &unscaledGlpyhWidth, &unscaledLeftSideBearing);
+    stbtt_GetCodepointHMetrics(&mFontInfo, character, &unscaledGlpyhWidth, &unscaledLeftSideBearing);
 
     fontCharacter.mGlyphWidth = unscaledGlpyhWidth * mPixelScale;
     fontCharacter.mLeftSideBearing = unscaledLeftSideBearing * mPixelScale;
@@ -65,7 +64,7 @@ FontCharacter Font::LoadCharacter(const char character)
     int yCoord1 = 0;
     int xCoord2 = 0;
     int yCoord2 = 0;
-    stbtt_GetCodepointBitmapBox(mFontInfo, character, mPixelScale, mPixelScale,
+    stbtt_GetCodepointBitmapBox(&mFontInfo, character, mPixelScale, mPixelScale,
                                 &xCoord1, &yCoord1, &xCoord2, &yCoord2);
 
     const int charWidth  = xCoord2 - xCoord1;
@@ -81,7 +80,7 @@ FontCharacter Font::LoadCharacter(const char character)
     {
         // Since this uses a single character for each texture, stride is just the pixel width of the character
         const int kStride = charWidth;
-        stbtt_MakeCodepointBitmap(mFontInfo, alphaTexture.data(),
+        stbtt_MakeCodepointBitmap(&mFontInfo, alphaTexture.data(),
                                     charWidth, charHeight, kStride,
                                     mPixelScale, mPixelScale,
                                     character);
@@ -108,7 +107,7 @@ FontString Font::GetCharacters(const std::string& text)
     float currentX = 0.0f;
     float currentY = 0.0f;
 
-    stbtt_InitFont(mFontInfo, mFontData.data(), 0);
+    stbtt_InitFont(&mFontInfo, mFontData.data(), 0);
 
     for (int i = 0; i < text.length(); i++)
     {
@@ -146,7 +145,7 @@ FontString Font::GetCharacters(const std::string& text)
         {
             // The kerning is the amount of space between a specific character pair
             // This can only be calculated if the next character is known
-            const int kern = stbtt_GetCodepointKernAdvance(mFontInfo, character, text[i + 1]);
+            const int kern = stbtt_GetCodepointKernAdvance(&mFontInfo, character, text[i + 1]);
             currentX += std::fabs(kern * mPixelScale);
         }
 

--- a/engine/graphics/font.cpp
+++ b/engine/graphics/font.cpp
@@ -21,8 +21,14 @@ static constexpr std::string_view DEFAULT_FONT_CHARACTERS =
 
 static constexpr int PIXEL_LINE_HEIGHT = 256;
 
+std::string Font::GetName() const
+{
+    return mName;
+}
+
 bool Font::LoadFont(const std::string& fontName, const std::string& fontPath)
 {
+    mName = fontName;
     std::ifstream file(fontPath, std::ios::binary);
     if (!file)
     {

--- a/engine/graphics/font.cpp
+++ b/engine/graphics/font.cpp
@@ -1,0 +1,171 @@
+#include "font.h"
+
+#include "image.h"
+#include "logger.h"
+#include "utils.h"
+
+#define STB_TRUETYPE_IMPLEMENTATION
+#include <stb_truetype.h>
+
+#include <fstream>
+
+namespace pong
+{
+
+// The font will load these characters by default.
+// If a character is not in this list, it will be loaded the first time it is used.
+static const std::string DEFAULT_FONT_CHARACTERS =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-=_+[]{}\\|;:'\",<.>/?`~ ";
+
+static constexpr int PIXEL_LINE_HEIGHT = 256;
+
+bool Font::LoadFont(const std::string& fontName, const std::string& fontPath)
+{
+    std::ifstream file(fontPath, std::ios::binary);
+    if (!file)
+    {
+        LogError("Failed to open true type font file: {} - {}", fontPath, fontName);
+        ASSERT(false);
+        return false;
+    }
+
+    mFontInfo = new stbtt_fontinfo();
+    mFontData = std::vector<unsigned char>(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+    ASSERT(stbtt_InitFont(mFontInfo, mFontData.data(), 0) != 0);
+
+    mPixelScale = stbtt_ScaleForPixelHeight(mFontInfo, static_cast<float>(PIXEL_LINE_HEIGHT));
+
+    int unscaledAscent, unscaledDescent, unscaledLineGap;
+    stbtt_GetFontVMetrics(mFontInfo, &unscaledAscent, &unscaledDescent, &unscaledLineGap);
+
+    mAscent  = unscaledAscent  * mPixelScale;
+    mDescent = unscaledDescent * mPixelScale;
+    mLineGap = unscaledLineGap * mPixelScale;
+
+    for (const char& character : DEFAULT_FONT_CHARACTERS)
+    {
+        LoadCharacter(character);
+    }
+
+    return true;
+}
+
+FontCharacter Font::LoadCharacter(const char character)
+{
+    FontCharacter fontCharacter {};
+
+    int unscaledGlpyhWidth = 0;
+    int unscaledLeftSideBearing = 0;
+    stbtt_GetCodepointHMetrics(mFontInfo, character, &unscaledGlpyhWidth, &unscaledLeftSideBearing);
+
+    fontCharacter.mGlyphWidth = unscaledGlpyhWidth * mPixelScale;
+    fontCharacter.mLeftSideBearing = unscaledLeftSideBearing * mPixelScale;
+
+    int xCoord1 = 0;
+    int yCoord1 = 0;
+    int xCoord2 = 0;
+    int yCoord2 = 0;
+    stbtt_GetCodepointBitmapBox(mFontInfo, character, mPixelScale, mPixelScale,
+                                &xCoord1, &yCoord1, &xCoord2, &yCoord2);
+
+    const int charWidth  = xCoord2 - xCoord1;
+    const int charHeight = yCoord2 - yCoord1;
+
+    std::vector<unsigned char> alphaTexture { 0 };
+    alphaTexture.resize(charWidth * charHeight);
+
+    const float spaceAboveCharPixels = mAscent + yCoord1;
+    fontCharacter.mYOffset = spaceAboveCharPixels;
+
+    if (character != '\n')
+    {
+        // Since this uses a single character for each texture, stride is just the pixel width of the character
+        const int kStride = charWidth;
+        stbtt_MakeCodepointBitmap(mFontInfo, alphaTexture.data(),
+                                    charWidth, charHeight, kStride,
+                                    mPixelScale, mPixelScale,
+                                    character);
+    }
+
+    // Bitmap returned is alpha only, and stored bottom left pixel first
+    // Convert to RGBA and flip it for OpenGL
+    const auto rgbTexture = image::ConvertAlphaImageToRGBA(alphaTexture);
+    fontCharacter.mBitmap = image::FlipImageVertically(rgbTexture, charWidth, charHeight, 4);
+    fontCharacter.mBitmapWidth  = charWidth;
+    fontCharacter.mBitmapHeight = charHeight;
+
+    mCharacters[character] = fontCharacter;
+    return fontCharacter;
+}
+
+FontString Font::GetCharacters(const std::string& text)
+{
+    std::vector<FontCharacter> fontCharacters {};
+
+    float totalTextWidth = 0.0f;
+    float totalTextHeight = 0.0f;
+    float currentLineHeight = 0.0f;
+    float currentX = 0.0f;
+    float currentY = 0.0f;
+
+    stbtt_InitFont(mFontInfo, mFontData.data(), 0);
+
+    for (int i = 0; i < text.length(); i++)
+    {
+        const char character = text[i];
+        FontCharacter fontCharacter = GetCharacter(character);
+
+        if (character == '\n')
+        {
+            currentX = 0;
+            currentY += (mAscent - mDescent + mLineGap);
+        }
+        else
+        {
+            currentLineHeight = std::fabs(fontCharacter.mYOffset - fontCharacter.mBitmapHeight);
+
+            // Left side bearing is the amount of space between the previous character and this one
+            // The first character does not need to take this into account
+            if (i > 0)
+            {
+                currentX += fontCharacter.mLeftSideBearing;
+            }
+
+            fontCharacter.mYOffset += currentY;
+            // Offset the character to the center of the quad
+            fontCharacter.mXOffset = currentX + fontCharacter.mBitmapWidth / 2.0f;
+            fontCharacter.mYOffset += fontCharacter.mBitmapHeight / 2.0f;
+
+            currentX += fontCharacter.mGlyphWidth;
+        }
+
+        totalTextWidth = std::max(totalTextWidth, currentX);
+        totalTextHeight = std::max(totalTextHeight, currentY + currentLineHeight);
+
+        if (i < text.length() - 1)
+        {
+            // The kerning is the amount of space between a specific character pair
+            // This can only be calculated if the next character is known
+            const int kern = stbtt_GetCodepointKernAdvance(mFontInfo, character, text[i + 1]);
+            currentX += std::fabs(kern * mPixelScale);
+        }
+
+        fontCharacters.push_back(fontCharacter);
+    }
+
+    return { fontCharacters, totalTextWidth, totalTextHeight };
+}
+
+// Gets the font character from the cache, or loads it if it doesn't exist
+FontCharacter Font::GetCharacter(const char character)
+{
+    auto it = mCharacters.find(character);
+    if (it == mCharacters.end())
+    {
+        return LoadCharacter(character);
+    }
+
+    return it->second;
+}
+
+} // namespace pong

--- a/engine/graphics/font.cpp
+++ b/engine/graphics/font.cpp
@@ -16,7 +16,7 @@ namespace pong
 
 // The font will load these characters by default.
 // If a character is not in this list, it will be loaded the first time it is used.
-static const std::string DEFAULT_FONT_CHARACTERS =
+static constexpr std::string_view DEFAULT_FONT_CHARACTERS =
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-=_+[]{}\\|;:'\",<.>/?`~ ";
 
 static constexpr int PIXEL_LINE_HEIGHT = 256;

--- a/engine/graphics/font.cpp
+++ b/engine/graphics/font.cpp
@@ -122,7 +122,7 @@ FontString Font::GetCharacters(const std::string& text)
         }
         else
         {
-            currentLineHeight = std::fabs(fontCharacter.mYOffset - fontCharacter.mBitmapHeight);
+            currentLineHeight = std::fabs(fontCharacter.mYOffset + fontCharacter.mBitmapHeight);
 
             // Left side bearing is the amount of space between the previous character and this one
             // The first character does not need to take this into account
@@ -162,6 +162,7 @@ FontCharacter Font::GetCharacter(const char character)
     auto it = mCharacters.find(character);
     if (it == mCharacters.end())
     {
+        LogDebug("Character {} not found in cache, loading it", character);
         return LoadCharacter(character);
     }
 

--- a/engine/graphics/font.h
+++ b/engine/graphics/font.h
@@ -46,7 +46,7 @@ private:
 
     std::unordered_map<char, FontCharacter> mCharacters {};
     std::vector<unsigned char> mFontData {};
-    stbtt_fontinfo* mFontInfo { nullptr };
+    stbtt_fontinfo mFontInfo {};
     float mPixelScale { 0 };
     float mAscent { 0 };
     float mDescent { 0 };

--- a/engine/graphics/font.h
+++ b/engine/graphics/font.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <stb_truetype.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+namespace pong
+{
+
+struct FontCharacter
+{
+    std::vector<unsigned char> mBitmap {};
+    int mBitmapWidth { 0 };
+    int mBitmapHeight { 0 };
+    float mXOffset { 0 };
+    float mYOffset { 0 };
+    float mLeftSideBearing { 0 };
+    float mGlyphWidth { 0 };
+};
+
+struct FontString
+{
+    const std::vector<FontCharacter> mFontCharacters {};
+    const float mWidth { 0 };
+    const float mHeight { 0 };
+};
+
+class Font
+{
+public:
+    Font() = default;
+    ~Font() = default;
+
+    bool LoadFont(const std::string& fontName, const std::string& fontPath);
+    FontString GetCharacters(const std::string& text);
+
+private:
+    FontCharacter LoadCharacter(const char character);
+    FontCharacter GetCharacter(const char character);
+
+    std::unordered_map<char, FontCharacter> mCharacters {};
+    std::vector<unsigned char> mFontData {};
+    stbtt_fontinfo* mFontInfo { nullptr };
+    float mPixelScale { 0 };
+    float mAscent { 0 };
+    float mDescent { 0 };
+    float mLineGap { 0 };
+
+};
+
+} // namespace pong

--- a/engine/graphics/font.h
+++ b/engine/graphics/font.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "image.h"
+
 #include <stb_truetype.h>
 
 #include <memory>
@@ -13,9 +15,7 @@ namespace pong
 // Represents a single character in a font, including offsets and its bitmap image.
 struct FontCharacter
 {
-    std::vector<unsigned char> mBitmap {};
-    int mBitmapWidth { 0 };
-    int mBitmapHeight { 0 };
+    Image mBitmap {};
     float mXOffset { 0 };
     float mYOffset { 0 };
     float mLeftSideBearing { 0 };

--- a/engine/graphics/font.h
+++ b/engine/graphics/font.h
@@ -12,6 +12,8 @@
 namespace pong
 {
 
+using image::Image;
+
 // Represents a single character in a font, including offsets and its bitmap image.
 struct FontCharacter
 {
@@ -37,6 +39,7 @@ public:
     Font() = default;
     ~Font() = default;
 
+    std::string GetName() const;
     bool LoadFont(const std::string& fontName, const std::string& fontPath);
     FontString GetCharacters(const std::string& text);
 
@@ -44,6 +47,7 @@ private:
     FontCharacter LoadCharacter(const char character);
     FontCharacter GetCharacter(const char character);
 
+    std::string mName {};
     std::unordered_map<char, FontCharacter> mCharacters {};
     std::vector<unsigned char> mFontData {};
     stbtt_fontinfo mFontInfo {};
@@ -51,7 +55,6 @@ private:
     float mAscent { 0 };
     float mDescent { 0 };
     float mLineGap { 0 };
-
 };
 
 } // namespace pong

--- a/engine/graphics/font.h
+++ b/engine/graphics/font.h
@@ -10,6 +10,7 @@
 namespace pong
 {
 
+// Represents a single character in a font, including offsets and its bitmap image.
 struct FontCharacter
 {
     std::vector<unsigned char> mBitmap {};
@@ -21,6 +22,8 @@ struct FontCharacter
     float mGlyphWidth { 0 };
 };
 
+// Represents a string of characters in a specific font, including offsets for each character.
+// And total width and height of the string.
 struct FontString
 {
     const std::vector<FontCharacter> mFontCharacters {};

--- a/engine/graphics/fontbank.cpp
+++ b/engine/graphics/fontbank.cpp
@@ -26,7 +26,6 @@ void FontBank::LoadFonts()
         const auto timeNow = std::chrono::system_clock::now();
         if (font.LoadFont(fontName, fontPath))
         {
-
             fontCount++;
             mFonts[fontName] = std::move(font);
 
@@ -36,6 +35,7 @@ void FontBank::LoadFonts()
         else
         {
             LogError("Failed to load font: {}", fontName);
+            ASSERT(false);
         }
     }
 
@@ -50,6 +50,7 @@ void FontBank::LoadFonts()
         return;
     }
 
+    // Set the default font text components will use. If not present use the first font loaded.
     mDefaultFontName = Config::GetValue<std::string>("default_font");
     if (mFonts.find(mDefaultFontName) == mFonts.end())
     {

--- a/engine/graphics/fontbank.cpp
+++ b/engine/graphics/fontbank.cpp
@@ -51,37 +51,36 @@ void FontBank::LoadFonts()
     }
 
     // Set the default font text components will use. If not present use the first font loaded.
-    mDefaultFontName = Config::GetValue<std::string>("default_font");
-    if (mFonts.find(mDefaultFontName) == mFonts.end())
+    const std::string defaultFontName = Config::GetValue<std::string>("default_font");
+    mDefaultFont = GetFont(defaultFontName);
+    if (mDefaultFont == nullptr)
     {
-        std::string newDefault = mFonts.begin()->first;
-        if (mDefaultFontName.empty())
+        mDefaultFont = &mFonts.begin()->second;
+        if (defaultFontName.empty())
         {
-            LogInfo("No default font specified, using {} as default", newDefault);
+            LogInfo("No default font specified, using {} as default", mDefaultFont->GetName());
         }
         else
         {
-            LogWarning("Default font not found: {}, using {} as default", mDefaultFontName, newDefault);
-            ASSERT(false);
+            LogWarning("Default font not found: {}, using {} as default", defaultFontName, mDefaultFont->GetName());
         }
-        mDefaultFontName = newDefault;
     }
 }
 
 Font* FontBank::GetFont(const std::string& fontName)
 {
-    auto font = mFonts.find(fontName);
-    if (font != mFonts.end())
+    auto fontIt = mFonts.find(fontName);
+    if (fontIt != mFonts.end())
     {
-        return &font->second;
+        return &fontIt->second;
     }
 
     return nullptr;
 }
 
-std::string FontBank::GetDefaultFontName() const
+Font* FontBank::GetDefaultFont()
 {
-    return mDefaultFontName;
+    return mDefaultFont;
 }
 
 } // namespace pong

--- a/engine/graphics/fontbank.cpp
+++ b/engine/graphics/fontbank.cpp
@@ -1,0 +1,86 @@
+#include "fontbank.h"
+
+#include "config.h"
+#include "logger.h"
+#include "utils.h"
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+namespace pong
+{
+
+void FontBank::LoadFonts()
+{
+    const std::optional<nlohmann::json> fonts = Config::GetJsonValue("fonts");
+    ASSERT(fonts.has_value());
+
+    int fontCount = 0;
+    for (const auto& font : fonts.value())
+    {
+        const std::string fontPath = font["path"];
+        const std::string fontName = font["name"];
+
+        Font font {};
+        const auto timeNow = std::chrono::system_clock::now();
+        if (font.LoadFont(fontName, fontPath))
+        {
+
+            fontCount++;
+            mFonts[fontName] = std::move(font);
+
+            const auto timeAfter = std::chrono::system_clock::now();
+            LogDebug("Loaded font {} in {}ms", fontName, std::chrono::duration_cast<std::chrono::milliseconds>(timeAfter - timeNow).count());
+        }
+        else
+        {
+            LogError("Failed to load font: {}", fontName);
+        }
+    }
+
+    if (fontCount > 0)
+    {
+        LogInfo("Loaded {} fonts", fontCount);
+    }
+    else
+    {
+        LogError("No fonts loaded!");
+        ASSERT(false);
+        return;
+    }
+
+    mDefaultFontName = Config::GetValue<std::string>("default_font");
+    if (mFonts.find(mDefaultFontName) == mFonts.end())
+    {
+        std::string newDefault = mFonts.begin()->first;
+        if (mDefaultFontName.empty())
+        {
+            LogInfo("No default font specified, using {} as default", newDefault);
+        }
+        else
+        {
+            LogWarning("Default font not found: {}, using {} as default", mDefaultFontName, newDefault);
+            ASSERT(false);
+        }
+        mDefaultFontName = newDefault;
+    }
+}
+
+Font* FontBank::GetFont(const std::string& fontName)
+{
+    auto font = mFonts.find(fontName);
+    if (font != mFonts.end())
+    {
+        return &font->second;
+    }
+
+    return nullptr;
+}
+
+std::string FontBank::GetDefaultFontName() const
+{
+    return mDefaultFontName;
+}
+
+} // namespace pong

--- a/engine/graphics/fontbank.h
+++ b/engine/graphics/fontbank.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "font.h"
+
+#include <unordered_map>
+
+namespace pong
+{
+
+class FontBank
+{
+public:
+    FontBank() = default;
+    ~FontBank() = default;
+
+    void LoadFonts();
+    Font* GetFont(const std::string& fontName);
+    std::string GetDefaultFontName() const;
+
+private:
+    std::unordered_map<std::string, Font> mFonts {};
+    std::string mDefaultFontName {};
+};
+
+} // namespace pong

--- a/engine/graphics/fontbank.h
+++ b/engine/graphics/fontbank.h
@@ -15,11 +15,11 @@ public:
 
     void LoadFonts();
     Font* GetFont(const std::string& fontName);
-    std::string GetDefaultFontName() const;
+    Font* GetDefaultFont();
 
 private:
     std::unordered_map<std::string, Font> mFonts {};
-    std::string mDefaultFontName {};
+    Font* mDefaultFont { nullptr };
 };
 
 } // namespace pong

--- a/engine/graphics/image.cpp
+++ b/engine/graphics/image.cpp
@@ -2,55 +2,62 @@
 
 #include "utils.h"
 
-namespace pong
-{
-
-namespace image
+namespace pong::image
 {
 
 /* Converts an alpha image to RGBA format. */
-std::vector<unsigned char> ConvertAlphaImageToRGBA(const std::vector<unsigned char>& imageData)
+Image ConvertAlphaImageToRGBA(const Image& image)
 {
-    std::vector<unsigned char> convertedImage {};
-    convertedImage.reserve(imageData.size() * 4);
+    ASSERT(image.mComponents == 1);
+
+    Image convertedImage {};
+    convertedImage.mPixels.reserve(image.mPixels.size() * 4);
 
     const unsigned char kFullColor = 255;
-    for (auto& alpha : imageData)
+    for (auto& alpha : image.mPixels)
     {
-        convertedImage.emplace_back(kFullColor);
-        convertedImage.emplace_back(kFullColor);
-        convertedImage.emplace_back(kFullColor);
-        convertedImage.emplace_back(alpha);
+        convertedImage.mPixels.push_back(kFullColor);
+        convertedImage.mPixels.push_back(kFullColor);
+        convertedImage.mPixels.push_back(kFullColor);
+        convertedImage.mPixels.push_back(alpha);
     }
+
+    convertedImage.mWidth = image.mWidth;
+    convertedImage.mHeight = image.mHeight;
+    convertedImage.mComponents = 4;
 
     return convertedImage;
 }
 
 /* Flips an image so top left element becomes bottom left element. */
-std::vector<unsigned char> FlipImageVertically(const std::vector<unsigned char>& imageData, int width, int height, int comp)
+Image FlipImageVertically(const Image& image)
 {
-    ASSERT(imageData.size() == width * height * comp);
+    const std::vector<unsigned char>& pixels = image.mPixels;
+    ASSERT(pixels.size() == image.mWidth * image.mHeight * image.mComponents);
 
-    std::vector<unsigned char> flippedImage {};
-    flippedImage.reserve(imageData.size());
+    Image flippedImage {};
+    flippedImage.mPixels.reserve(pixels.size());
 
-    const int stride = width * comp;
-    for (int rowNumber = height - 1; rowNumber >= 0; rowNumber--)
+    const int stride = image.mWidth * image.mComponents;
+    for (int rowNumber = image.mHeight - 1; rowNumber >= 0; rowNumber--)
     {
         const int rowIndex = rowNumber * stride;
-        for (int colNumber = 0; colNumber < width; colNumber++)
+        for (int colNumber = 0; colNumber < image.mWidth; colNumber++)
         {
             // For each pixel, copy all the components
-            const int pixelIndex = rowIndex + (colNumber * comp);
-            for (int componentIndex = 0; componentIndex < comp; componentIndex++)
+            const int pixelIndex = rowIndex + (colNumber * image.mComponents);
+            for (int componentIndex = 0; componentIndex < image.mComponents; componentIndex++)
             {
-                flippedImage.emplace_back(imageData[pixelIndex + componentIndex]);
+                flippedImage.mPixels.push_back(pixels[pixelIndex + componentIndex]);
             }
         }
     }
 
+    flippedImage.mWidth = image.mWidth;
+    flippedImage.mHeight = image.mHeight;
+    flippedImage.mComponents = image.mComponents;
+
     return flippedImage;
 }
 
-} // namespace image
-} // namespace pong
+} // namespace pong::image

--- a/engine/graphics/image.cpp
+++ b/engine/graphics/image.cpp
@@ -1,0 +1,56 @@
+#include "image.h"
+
+#include "utils.h"
+
+namespace pong
+{
+
+namespace image
+{
+
+/* Converts an alpha image to RGBA format. */
+std::vector<unsigned char> ConvertAlphaImageToRGBA(const std::vector<unsigned char>& imageData)
+{
+    std::vector<unsigned char> convertedImage {};
+    convertedImage.reserve(imageData.size() * 4);
+
+    const unsigned char kFullColor = 255;
+    for (auto& alpha : imageData)
+    {
+        convertedImage.emplace_back(kFullColor);
+        convertedImage.emplace_back(kFullColor);
+        convertedImage.emplace_back(kFullColor);
+        convertedImage.emplace_back(alpha);
+    }
+
+    return convertedImage;
+}
+
+/* Flips an image so top left element becomes bottom left element. */
+std::vector<unsigned char> FlipImageVertically(const std::vector<unsigned char>& imageData, int width, int height, int comp)
+{
+    ASSERT(imageData.size() == width * height * comp);
+
+    std::vector<unsigned char> flippedImage {};
+    flippedImage.reserve(imageData.size());
+
+    const int stride = width * comp;
+    for (int rowNumber = height - 1; rowNumber >= 0; rowNumber--)
+    {
+        const int rowIndex = rowNumber * stride;
+        for (int colNumber = 0; colNumber < width; colNumber++)
+        {
+            // For each pixel, copy all the components
+            const int pixelIndex = rowIndex + (colNumber * comp);
+            for (int componentIndex = 0; componentIndex < comp; componentIndex++)
+            {
+                flippedImage.emplace_back(imageData[pixelIndex + componentIndex]);
+            }
+        }
+    }
+
+    return flippedImage;
+}
+
+} // namespace image
+} // namespace pong

--- a/engine/graphics/image.h
+++ b/engine/graphics/image.h
@@ -5,11 +5,20 @@
 namespace pong
 {
 
-namespace image
+struct Image
+{
+    std::vector<unsigned char> mPixels {};
+    int mWidth { 0 };
+    int mHeight { 0 };
+    int mComponents { 0 };
+};
+
+} // namespace pong
+
+namespace pong::image
 {
 
-std::vector<unsigned char> ConvertAlphaImageToRGBA(const std::vector<unsigned char>& imageData);
-std::vector<unsigned char> FlipImageVertically(const std::vector<unsigned char>& imageData, int width, int height, int comp);
+Image ConvertAlphaImageToRGBA(const Image& image);
+Image FlipImageVertically(const Image& image);
 
-} // namespace image
-} // namespace pong
+} // namespace pong::image

--- a/engine/graphics/image.h
+++ b/engine/graphics/image.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <vector>
+
+namespace pong
+{
+
+namespace image
+{
+
+std::vector<unsigned char> ConvertAlphaImageToRGBA(const std::vector<unsigned char>& imageData);
+std::vector<unsigned char> FlipImageVertically(const std::vector<unsigned char>& imageData, int width, int height, int comp);
+
+} // namespace image
+} // namespace pong

--- a/engine/graphics/image.h
+++ b/engine/graphics/image.h
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-namespace pong
+namespace pong::image
 {
 
 struct Image
@@ -13,10 +13,6 @@ struct Image
     int mComponents { 0 };
 };
 
-} // namespace pong
-
-namespace pong::image
-{
 
 Image ConvertAlphaImageToRGBA(const Image& image);
 Image FlipImageVertically(const Image& image);

--- a/engine/graphics/textcharacter.cpp
+++ b/engine/graphics/textcharacter.cpp
@@ -10,13 +10,12 @@ static const std::array<unsigned int, 6> kIndicies = {
     2, 3, 0
 };
 
-TextCharacter::TextCharacter(const std::vector<unsigned char>& data,
-                            float width, float height, const glm::vec3& offset,
-                            int textureWidthPixels, int textureHeightPixels) :
+TextCharacter::TextCharacter(const Image& image, const glm::vec3& offset,
+                             float width, float height) :
     Rectangle(width, height),
     mOffset(offset)
 {
-    mTexture = Texture(data, textureWidthPixels, textureHeightPixels);
+    mTexture = Texture(image.mPixels, image.mWidth, image.mHeight);
 }
 
 } // namespace pong

--- a/engine/graphics/textcharacter.h
+++ b/engine/graphics/textcharacter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "image.h"
 #include "mesh.h"
 #include "rectangle.h"
 
@@ -13,9 +14,8 @@ namespace pong
 class TextCharacter : public Rectangle
 {
 public:
-    TextCharacter(const std::vector<unsigned char>& data,
-                  float width, float height, const glm::vec3& offset,
-                  int textureWidthPixels, int textureHeightPixels);
+    TextCharacter(const Image& image, const glm::vec3& offset,
+                  float width, float height);
 
     glm::vec3 mOffset { 0.0f };
 };

--- a/engine/graphics/textcharacter.h
+++ b/engine/graphics/textcharacter.h
@@ -11,6 +11,8 @@
 namespace pong
 {
 
+using image::Image;
+
 class TextCharacter : public Rectangle
 {
 public:

--- a/engine/logger/logger.h
+++ b/engine/logger/logger.h
@@ -77,7 +77,7 @@ void LogInfo(const char* format, Args... args)
 template<typename... Args>
 void LogWarning(const char* format, Args... args)
 {
-    Logger::GetInstance().Log(spdlog:level::warn, format, std::forward<Args>(args)...);
+    Logger::GetInstance().Log(spdlog::level::warn, format, std::forward<Args>(args)...);
 }
 
 template<typename... Args>

--- a/engine/pong.cpp
+++ b/engine/pong.cpp
@@ -36,6 +36,11 @@ AudioMixer& Pong::GetAudioMixer()
     return mAudioMixer;
 }
 
+FontBank& Pong::GetFontBank()
+{
+    return mFontBank;
+}
+
 Timer& Pong::GetTimer()
 {
     return mTimer;
@@ -44,6 +49,7 @@ Timer& Pong::GetTimer()
 void Pong::Init()
 {
     GetInstance().GetAudioMixer().Init();
+    GetInstance().mFontBank.LoadFonts();
     GetInstance().mSceneLoader.PreLoadScenes();
     GetInstance().GetTimer().Init();
 

--- a/engine/pong.h
+++ b/engine/pong.h
@@ -4,6 +4,7 @@
 #include "collisionmanager.h"
 #include "component.h"
 #include "componentmanager.h"
+#include "fontbank.h"
 #include "gameobject.h"
 #include "sceneloader.h"
 #include "text.h"
@@ -72,6 +73,7 @@ public:
     ComponentManager& GetComponentManager();
     UIEventManager& GetUIEventManager();
     AudioMixer& GetAudioMixer();
+    FontBank& GetFontBank();
     Timer& GetTimer();
 
 private:
@@ -91,6 +93,7 @@ private:
     UIEventManager mUIEventManager {};
     SceneLoader mSceneLoader {};
     AudioMixer mAudioMixer {};
+    FontBank mFontBank {};
     Timer mTimer {};
 
     std::string mNextScene { "Title" };

--- a/engine/renderer.cpp
+++ b/engine/renderer.cpp
@@ -110,9 +110,7 @@ void Renderer::Draw(const std::vector<OffsetGraphic>& graphics, const glm::vec3&
 {
     for (const auto& graphic : graphics)
     {
-        const glm::vec3 newOffset = position + graphic.mOffset;
-        // std::cout << "New offset: " << newOffset.x << ", " << newOffset.y << std::endl;
-        Draw(graphic.mGraphic, newOffset);
+        Draw(graphic.mGraphic, position + graphic.mOffset);
     }
 }
 

--- a/engine/renderer.cpp
+++ b/engine/renderer.cpp
@@ -110,7 +110,9 @@ void Renderer::Draw(const std::vector<OffsetGraphic>& graphics, const glm::vec3&
 {
     for (const auto& graphic : graphics)
     {
-        Draw(graphic.mGraphic, position + graphic.mOffset);
+        const glm::vec3 newOffset = position + graphic.mOffset;
+        // std::cout << "New offset: " << newOffset.x << ", " << newOffset.y << std::endl;
+        Draw(graphic.mGraphic, newOffset);
     }
 }
 

--- a/engine/scene/componentdeserializer.cpp
+++ b/engine/scene/componentdeserializer.cpp
@@ -98,11 +98,6 @@ void ComponentDeserializer::VisitComponent(Text* component)
         component->mScale = mCurrentJson["scale"];
     }
 
-    if (mCurrentJson.contains("pixel_height"))
-    {
-        component->mPixelLineHeight = mCurrentJson["pixel_height"];
-    }
-
     if (mCurrentJson.contains("color"))
     {
         ASSERT(mCurrentJson["color"].is_object());

--- a/engine/scene/componentdeserializer.cpp
+++ b/engine/scene/componentdeserializer.cpp
@@ -105,6 +105,20 @@ void ComponentDeserializer::VisitComponent(Text* component)
         component->SetColor({color["r"], color["g"], color["b"], color["a"]});
     }
 
+    if (mCurrentJson.contains("font"))
+    {
+        const std::string fontName = mCurrentJson["font"];
+        Font* font = Pong::GetInstance().GetFontBank().GetFont(fontName);
+        ASSERT(font != nullptr);
+        component->mFont = font;
+    }
+    else
+    {
+        Font* font = Pong::GetInstance().GetFontBank().GetDefaultFont();
+        ASSERT(font != nullptr);
+        component->mFont = font;
+    }
+
     component->RecomputeText();
 
     if (mCurrentJson.contains("order_layer"))

--- a/render/texture.cpp
+++ b/render/texture.cpp
@@ -1,5 +1,6 @@
 #include "texture.h"
 
+#include "image.h"
 #include "renderutils.h"
 
 // Ignore numerous warnings from stb_image.h
@@ -33,10 +34,10 @@ Texture::Texture(const std::string& filePath)
 
 Texture::Texture(const std::vector<unsigned char>& alphaImage, int width, int height)
 {
-    auto rgbTexture = Texture::ConvertAlphaImageToRGBA(alphaImage);
-    auto finalImage = Texture::FlipImageVertically(rgbTexture, width, height, 4);
+    // auto rgbTexture = image::ConvertAlphaImageToRGBA(alphaImage);
+    // auto finalImage = image::FlipImageVertically(rgbTexture, width, height, 4);
 
-    this->Texture::Texture(*finalImage.data(), width, height, GL_RGBA);
+    this->Texture::Texture(*alphaImage.data(), width, height, GL_RGBA);
 }
 
 Texture::Texture(const RGBAColor& color)
@@ -113,49 +114,6 @@ int Texture::GetHeight() const
 int Texture::GetWidth() const
 {
     return mWidth;
-}
-
-/* Converts a grayscale image to RGBA format */
-std::vector<unsigned char> Texture::ConvertAlphaImageToRGBA(const std::vector<unsigned char>& imageData)
-{
-    std::vector<unsigned char> convertedImage {};
-    convertedImage.reserve(imageData.size() * 4);
-
-    const unsigned char kFullColor = 255;
-    for (auto& alpha : imageData)
-    {
-        convertedImage.emplace_back(kFullColor);
-        convertedImage.emplace_back(kFullColor);
-        convertedImage.emplace_back(kFullColor);
-        convertedImage.emplace_back(alpha);
-    }
-
-    return convertedImage;
-}
-
-std::vector<unsigned char> Texture::FlipImageVertically(const std::vector<unsigned char>& imageData, int width, int height, int comp)
-{
-    ASSERT(imageData.size() == width * height * comp);
-
-    std::vector<unsigned char> flippedImage {};
-    flippedImage.reserve(imageData.size());
-
-    const int stride = width * comp;
-    for (int rowNumber = height - 1; rowNumber >= 0; rowNumber--)
-    {
-        const int rowIndex = rowNumber * stride;
-        for (int colNumber = 0; colNumber < width; colNumber++)
-        {
-            // For each pixel, copy all the components
-            const int pixelIndex = rowIndex + (colNumber * comp);
-            for (int componentIndex = 0; componentIndex < comp; componentIndex++)
-            {
-                flippedImage.emplace_back(imageData[pixelIndex + componentIndex]);
-            }
-        }
-    }
-
-    return flippedImage;
 }
 
 } // namespace pong

--- a/render/texture.cpp
+++ b/render/texture.cpp
@@ -32,12 +32,9 @@ Texture::Texture(const std::string& filePath)
     }
 }
 
-Texture::Texture(const std::vector<unsigned char>& alphaImage, int width, int height)
+Texture::Texture(const std::vector<unsigned char>& rgbaImage, int width, int height)
 {
-    // auto rgbTexture = image::ConvertAlphaImageToRGBA(alphaImage);
-    // auto finalImage = image::FlipImageVertically(rgbTexture, width, height, 4);
-
-    this->Texture::Texture(*alphaImage.data(), width, height, GL_RGBA);
+    this->Texture::Texture(*rgbaImage.data(), width, height, GL_RGBA);
 }
 
 Texture::Texture(const RGBAColor& color)

--- a/render/texture.h
+++ b/render/texture.h
@@ -35,9 +35,6 @@ public:
     int GetWidth() const;
     int GetHeight() const;
 
-    static std::vector<unsigned char> ConvertAlphaImageToRGBA(const std::vector<unsigned char>& imageData);
-    static std::vector<unsigned char> FlipImageVertically(const std::vector<unsigned char>& imageData, int width, int height, int comp);
-
 protected:
     int mWidth {0};
     int mHeight {0};

--- a/render/texture.h
+++ b/render/texture.h
@@ -17,7 +17,7 @@ public:
     Texture(const std::string& filePath);
     Texture(const RGBAColor& color);
     /* Assumes the data is grayscale and stored from top left to bottom right in vector */
-    Texture(const std::vector<unsigned char>& alphaImage, int width, int height);
+    Texture(const std::vector<unsigned char>& rgbaImage, int width, int height);
     Texture(const unsigned char& imageData, int width, int height, GLenum format);
 
     // Copy constructors are deleted because the renderer id is used to destroy the object in opengl


### PR DESCRIPTION
Prevously if a text component was changed/created it would open the font file, read it, and create the character images using stb true type. This can be costly to do over and over each frame the text is changed. 

Instead `Font` objects are created at initalization and stored within the engine. It contains most the details for each font's character including the bitmap image of the character, its offsets, and sizing data. This way when recomputing the text component, it only needs to add some offsets together to get the new text data.

Previously measured loadtimes for the 3 mains scene and their new load times are as follows
Title       100-115ms -> 1-5ms
Settings 285-300ms -> 6-8ms
Game     39-40ms     -> 0-1ms
So a massive improvement! Of course there is a slight tradeoff that the initalization of the engine will take longer to complete.

Some things to note/ignore:
A lot of this is moving computations from text.cpp to font.cpp
Changes to scene files were made to adjust to new default scaling of fonts

The main idea is that the `FontBank` will load all fonts present in the config and store them in a map where a font name maps to a new font object. Text components will look for this font object, and give it the text it wants to create a component from. The font object will give back a `FontString` along with a vector of `FontCharacters`. Using the data from these objects, each text character can be made.

Another smallish change is the use of a new namespace `image` Instead of Texture holding the methods `ConvertAlphaImageToRGBA` and `FlipImageVertically` statically, they are free functions under the namespace `image`