### PR TITLE
Remove most singletons from engine creation.

### DIFF
--- a/assets/gameover.scene
+++ b/assets/gameover.scene
@@ -26,13 +26,13 @@
         },
         {
           "type": "Button",
-          "width": 400,
-          "height": 200
+          "width": 500,
+          "height": 250
         },
         {
           "type": "Text",
-          "text": "Play Again",
-          "scale": 0.3,
+          "text": "Play\nAgain",
+          "scale": 0.45,
           "color": {
             "r": 0,
             "g": 0,
@@ -52,13 +52,13 @@
         },
         {
           "type": "Button",
-          "width": 400,
-          "height": 200
+          "width": 500,
+          "height": 250
         },
         {
           "type": "Text",
-          "text": "Main Menu",
-          "scale": 0.3,
+          "text": "Main\nMenu",
+          "scale": 0.45,
           "color": {
             "r": 0,
             "g": 0,
@@ -78,13 +78,13 @@
         },
         {
           "type": "Button",
-          "width": 400,
-          "height": 200
+          "width": 500,
+          "height": 250
         },
         {
           "type": "Text",
           "text": "Quit",
-          "scale": 0.5,
+          "scale": 0.6,
           "color": {
             "r": 0,
             "g": 0,

--- a/assets/settings.scene
+++ b/assets/settings.scene
@@ -79,7 +79,7 @@
           "type": "Slider",
           "width": 1000.0,
           "height": 100.0,
-          "min": 0,
+          "min": 1,
           "max": 4000,
           "step": 1,
           "start_value": 0

--- a/components/behavior.cpp
+++ b/components/behavior.cpp
@@ -6,19 +6,4 @@
 namespace pong
 {
 
-void Behavior::SetTimeout(const std::chrono::duration<double>& timeout, const std::function<void()>& callback)
-{
-    Pong::GetInstance().GetTimer().AddTimer(GetGameObjectId(), timeout, callback);
-}
-
-void Behavior::PlaySound(const Sound& sound)
-{
-    Pong::GetInstance().GetAudioMixer().PlaySound(sound);
-}
-
-void Behavior::PlaySound(const Sound& sound, const glm::vec3& position)
-{
-    Pong::GetInstance().GetAudioMixer().PlaySound(sound, position);
-}
-
 } // namespace pong

--- a/components/behavior.h
+++ b/components/behavior.h
@@ -27,10 +27,6 @@ public:
     virtual void OnCollisionStay(GameObject& /*other*/) {};
     virtual void OnCollisionStop(GameObject& /*other*/) {};
 
-    void SetTimeout(const std::chrono::duration<double>& timeout, const std::function<void()>& callback);
-    void PlaySound(const Sound& sound);
-    void PlaySound(const Sound& sound, const glm::vec3& position);
-
     bool mOnStartCalled { false };
 };
 

--- a/components/uicomponent.cpp
+++ b/components/uicomponent.cpp
@@ -14,7 +14,7 @@ int UIComponent::GetOrderLayer() const
 void UIComponent::SetOrderLayer(int orderLayer)
 {
     mOrderLayer = orderLayer;
-    game::GetPongInstance()->GetComponentManager().UpdateUIComponentOrderLayers();
+    globals::game::GetPongInstance()->GetComponentManager().UpdateUIComponentOrderLayers();
 }
 
 } // namespace pong

--- a/components/uicomponent.cpp
+++ b/components/uicomponent.cpp
@@ -14,7 +14,7 @@ int UIComponent::GetOrderLayer() const
 void UIComponent::SetOrderLayer(int orderLayer)
 {
     mOrderLayer = orderLayer;
-    Pong::GetInstance().GetComponentManager().UpdateUIComponentOrderLayers();
+    game::GetPongInstance()->GetComponentManager().UpdateUIComponentOrderLayers();
 }
 
 } // namespace pong

--- a/engine/applicationwindow.cpp
+++ b/engine/applicationwindow.cpp
@@ -37,7 +37,7 @@ void ApplicationWindow::Init()
         ASSERT(false);
     }
 
-    glfwSetFramebufferSizeCallback(mWindow, application::WindowResizeCallback);
+    glfwSetFramebufferSizeCallback(mWindow, globals::application::WindowResizeCallback);
     glfwMakeContextCurrent(mWindow);
     SetVSync(Config::GetValue("vsync", false));
 
@@ -115,7 +115,7 @@ GLFWwindow* ApplicationWindow::GetWindow() const
 
 } // namespace pong
 
-namespace pong::application
+namespace pong::globals::application
 {
 
 ApplicationWindow* gApplicationWindow { nullptr };
@@ -165,4 +165,4 @@ void SetVSync(bool active)
     GetWindowInstance()->SetVSync(active);
 }
 
-}
+} // namespace pong::globals::application

--- a/engine/applicationwindow.cpp
+++ b/engine/applicationwindow.cpp
@@ -15,12 +15,6 @@ using image::Image;
 static constexpr int SCREEN_WIDTH = 1280;
 static constexpr int SCREEN_HEIGHT = 960;
 
-ApplicationWindow& ApplicationWindow::GetInstance()
-{
-    static ApplicationWindow instance;
-    return instance;
-}
-
 void ApplicationWindow::Init()
 {
     if (!glfwInit())
@@ -35,16 +29,16 @@ void ApplicationWindow::Init()
 
     GLFWmonitor* kMonitor = nullptr;
     GLFWwindow* kShare = nullptr;
-    GetInstance().mWindow = glfwCreateWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Pong", kMonitor, kShare);
-    if (GetInstance().mWindow == nullptr)
+    mWindow = glfwCreateWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Pong", kMonitor, kShare);
+    if (mWindow == nullptr)
     {
         LogError("glfwCreateWindow() failure");
         glfwTerminate();
         ASSERT(false);
     }
 
-    glfwSetFramebufferSizeCallback(GetInstance().mWindow, ApplicationWindow::WindowResizeCallback);
-    glfwMakeContextCurrent(GetInstance().mWindow);
+    glfwSetFramebufferSizeCallback(mWindow, application::WindowResizeCallback);
+    glfwMakeContextCurrent(mWindow);
     SetVSync(Config::GetValue("vsync", false));
 
     LogInfo("Window created: {}x{}", SCREEN_WIDTH, SCREEN_HEIGHT);
@@ -52,36 +46,36 @@ void ApplicationWindow::Init()
 
 void ApplicationWindow::SwapBuffers()
 {
-    glfwSwapBuffers(GetInstance().mWindow);
+    glfwSwapBuffers(mWindow);
     glfwPollEvents();
 }
 
 void ApplicationWindow::Cleanup()
 {
-    glfwDestroyWindow(GetInstance().mWindow);
+    glfwDestroyWindow(mWindow);
     glfwTerminate();
 }
 
-int ApplicationWindow::GetScreenWidth()
+int ApplicationWindow::GetScreenWidth() const
 {
-    return GetInstance().mScreenWidth;
+    return mScreenWidth;
 }
 
-int ApplicationWindow::GetScreenHeight()
+int ApplicationWindow::GetScreenHeight() const
 {
-    return GetInstance().mScreenHeight;
+    return mScreenHeight;
 }
 
 void ApplicationWindow::WindowResizeCallback(GLFWwindow* /*window*/, int width, int height)
 {
-    GetInstance().mScreenWidth = width;
-    GetInstance().mScreenHeight = height;
+    mScreenWidth = width;
+    mScreenHeight = height;
     glViewport(0, 0, width, height);
 }
 
 void ApplicationWindow::SetWindowTitle(const std::string& title)
 {
-    glfwSetWindowTitle(GetInstance().mWindow, title.c_str());
+    glfwSetWindowTitle(mWindow, title.c_str());
 }
 
 void ApplicationWindow::SetWindowIcon(const std::string& iconPath)
@@ -89,28 +83,28 @@ void ApplicationWindow::SetWindowIcon(const std::string& iconPath)
     Image icon = image::LoadImage(iconPath);
     GLFWimage image = { icon.mWidth, icon.mHeight, icon.mPixels.data() };
 
-    glfwSetWindowIcon(GetInstance().mWindow, 1, &image);
+    glfwSetWindowIcon(mWindow, 1, &image);
 }
 
-bool ApplicationWindow::ShouldClose()
+bool ApplicationWindow::ShouldClose() const
 {
-    return glfwWindowShouldClose(GetInstance().mWindow);
+    return glfwWindowShouldClose(mWindow);
 }
 
 void ApplicationWindow::SetShouldCloseWindow()
 {
-    glfwSetWindowShouldClose(GetInstance().mWindow, GLFW_TRUE);
+    glfwSetWindowShouldClose(mWindow, GLFW_TRUE);
 }
 
-bool ApplicationWindow::IsVSyncActive()
+bool ApplicationWindow::IsVSyncActive() const
 {
-    return GetInstance().mVSync;
+    return mVSync;
 }
 
 void ApplicationWindow::SetVSync(bool active)
 {
-    GetInstance().mVSync = active;
-    glfwSwapInterval(GetInstance().mVSync ? GLFW_TRUE : GLFW_FALSE);
+    mVSync = active;
+    glfwSwapInterval(mVSync ? GLFW_TRUE : GLFW_FALSE);
     Config::SetValue("vsync", active);
 }
 
@@ -120,3 +114,55 @@ GLFWwindow* ApplicationWindow::GetWindow() const
 }
 
 } // namespace pong
+
+namespace pong::application
+{
+
+ApplicationWindow* gApplicationWindow { nullptr };
+
+ApplicationWindow* GetWindowInstance()
+{
+    return gApplicationWindow;
+}
+
+void SetWindowInstance(ApplicationWindow* window)
+{
+    gApplicationWindow = window;
+}
+
+void WindowResizeCallback(GLFWwindow* window, int width, int height)
+{
+    GetWindowInstance()->WindowResizeCallback(window, width, height);
+}
+
+int GetScreenWidth()
+{
+    return GetWindowInstance()->GetScreenWidth();
+}
+
+int GetScreenHeight()
+{
+    return GetWindowInstance()->GetScreenHeight();
+}
+
+void SetWindowTitle(const std::string& title)
+{
+    GetWindowInstance()->SetWindowTitle(title);
+}
+
+void SetWindowIcon(const std::string& iconPath)
+{
+    GetWindowInstance()->SetWindowIcon(iconPath);
+}
+
+bool IsVSyncActive()
+{
+    return GetWindowInstance()->IsVSyncActive();
+}
+
+void SetVSync(bool active)
+{
+    GetWindowInstance()->SetVSync(active);
+}
+
+}

--- a/engine/applicationwindow.h
+++ b/engine/applicationwindow.h
@@ -11,35 +11,29 @@ namespace pong
 class ApplicationWindow
 {
 public:
-    static ApplicationWindow& GetInstance();
+    ApplicationWindow() = default;
+    ~ApplicationWindow() = default;
 
-    static void Init();
-    static void SwapBuffers();
-    static void Cleanup();
+    void Init();
+    void SwapBuffers();
+    void Cleanup();
 
-    static int GetScreenWidth();
-    static int GetScreenHeight();
-    static void WindowResizeCallback(GLFWwindow* window, int width, int height);
+    int GetScreenWidth() const;
+    int GetScreenHeight() const;
+    void WindowResizeCallback(GLFWwindow* window, int width, int height);
 
-    static void SetWindowTitle(const std::string& title);
-    static void SetWindowIcon(const std::string& iconPath);
+    void SetWindowTitle(const std::string& title);
+    void SetWindowIcon(const std::string& iconPath);
 
-    static bool ShouldClose();
-    static void SetShouldCloseWindow();
+    bool ShouldClose() const;
+    void SetShouldCloseWindow();
 
-    static bool IsVSyncActive();
-    static void SetVSync(bool active);
+    bool IsVSyncActive() const;
+    void SetVSync(bool active);
 
     GLFWwindow* GetWindow() const;
 
 private:
-    ApplicationWindow() = default;
-    ~ApplicationWindow() = default;
-    ApplicationWindow(const ApplicationWindow&) = delete;
-    ApplicationWindow& operator=(const ApplicationWindow&) = delete;
-    ApplicationWindow(ApplicationWindow&&) = delete;
-    ApplicationWindow& operator=(ApplicationWindow&&) = delete;
-
     GLFWwindow* mWindow { nullptr };
     int mScreenWidth { 1280 };
     int mScreenHeight { 960 };
@@ -47,3 +41,22 @@ private:
 };
 
 } // namespace pong
+
+namespace pong::application
+{
+
+extern ApplicationWindow* gApplicationWindow;
+
+ApplicationWindow* GetWindowInstance();
+void SetWindowInstance(ApplicationWindow* window);
+
+void WindowResizeCallback(GLFWwindow* window, int width, int height);
+
+int GetScreenWidth();
+int GetScreenHeight();
+void SetWindowTitle(const std::string& title);
+void SetWindowIcon(const std::string& iconPath);
+bool IsVSyncActive();
+void SetVSync(bool active);
+
+}

--- a/engine/applicationwindow.h
+++ b/engine/applicationwindow.h
@@ -42,7 +42,7 @@ private:
 
 } // namespace pong
 
-namespace pong::application
+namespace pong::globals::application
 {
 
 extern ApplicationWindow* gApplicationWindow;
@@ -59,4 +59,4 @@ void SetWindowIcon(const std::string& iconPath);
 bool IsVSyncActive();
 void SetVSync(bool active);
 
-}
+} // namespace pong::globals::application

--- a/engine/audio/audiomixer.cpp
+++ b/engine/audio/audiomixer.cpp
@@ -208,34 +208,44 @@ namespace pong::audio
 
 AudioMixer* gAudioMixer { nullptr };
 
+AudioMixer* GetAudioMixerInstance()
+{
+    return gAudioMixer;
+}
+
+void SetAudioMixerInstance(AudioMixer* audioMixer)
+{
+    gAudioMixer = audioMixer;
+}
+
 void PlaySound(const Sound& sound)
 {
-    gAudioMixer->PlaySound(sound);
+    GetAudioMixerInstance()->PlaySound(sound);
 }
 
 void PlaySound(const Sound& sound, const glm::vec3& position)
 {
-    gAudioMixer->PlaySound(sound, position);
+    GetAudioMixerInstance()->PlaySound(sound, position);
 }
 
 float GetVolume()
 {
-    return gAudioMixer->GetVolume();
+    return GetAudioMixerInstance()->GetVolume();
 }
 
 void SetVolume(float volume)
 {
-    gAudioMixer->SetVolume(volume);
+    GetAudioMixerInstance()->SetVolume(volume);
 }
 
 bool GetSpatialAudioEnabled()
 {
-    return gAudioMixer->GetSpatialAudioEnabled();
+    return GetAudioMixerInstance()->GetSpatialAudioEnabled();
 }
 
 void SetSpatialAudioEnabled(bool enabled)
 {
-    gAudioMixer->SetSpatialAudioEnabled(enabled);
+    GetAudioMixerInstance()->SetSpatialAudioEnabled(enabled);
 }
 
 }

--- a/engine/audio/audiomixer.cpp
+++ b/engine/audio/audiomixer.cpp
@@ -28,7 +28,7 @@ int AudioCallbackWrapper(const void* inputBuffer, void* outputBuffer,
                   PaStreamCallbackFlags statusFlags,
                   void* userData)
 {
-    return audio::GetAudioMixerInstance()->AudioCallback(inputBuffer, outputBuffer, framesPerBuffer, timeInfo, statusFlags, userData);
+    return globals::audio::GetAudioMixerInstance()->AudioCallback(inputBuffer, outputBuffer, framesPerBuffer, timeInfo, statusFlags, userData);
 }
 
 void AudioMixer::Init()
@@ -203,7 +203,7 @@ void AudioMixer::SetSpatialAudioEnabled(bool enabled)
 
 } // namespace pong
 
-namespace pong::audio
+namespace pong::globals::audio
 {
 
 AudioMixer* gAudioMixer { nullptr };
@@ -248,4 +248,4 @@ void SetSpatialAudioEnabled(bool enabled)
     GetAudioMixerInstance()->SetSpatialAudioEnabled(enabled);
 }
 
-}
+} // namespace pong::globals::audio

--- a/engine/audio/audiomixer.cpp
+++ b/engine/audio/audiomixer.cpp
@@ -202,3 +202,40 @@ void AudioMixer::SetSpatialAudioEnabled(bool enabled)
 }
 
 } // namespace pong
+
+namespace pong::audio
+{
+
+AudioMixer* gAudioMixer { nullptr };
+
+void PlaySound(const Sound& sound)
+{
+    gAudioMixer->PlaySound(sound);
+}
+
+void PlaySound(const Sound& sound, const glm::vec3& position)
+{
+    gAudioMixer->PlaySound(sound, position);
+}
+
+float GetVolume()
+{
+    return gAudioMixer->GetVolume();
+}
+
+void SetVolume(float volume)
+{
+    gAudioMixer->SetVolume(volume);
+}
+
+bool GetSpatialAudioEnabled()
+{
+    return gAudioMixer->GetSpatialAudioEnabled();
+}
+
+void SetSpatialAudioEnabled(bool enabled)
+{
+    gAudioMixer->SetSpatialAudioEnabled(enabled);
+}
+
+}

--- a/engine/audio/audiomixer.cpp
+++ b/engine/audio/audiomixer.cpp
@@ -28,7 +28,7 @@ int AudioCallbackWrapper(const void* inputBuffer, void* outputBuffer,
                   PaStreamCallbackFlags statusFlags,
                   void* userData)
 {
-    return Pong::GetInstance().GetAudioMixer().AudioCallback(inputBuffer, outputBuffer, framesPerBuffer, timeInfo, statusFlags, userData);
+    return audio::GetAudioMixerInstance()->AudioCallback(inputBuffer, outputBuffer, framesPerBuffer, timeInfo, statusFlags, userData);
 }
 
 void AudioMixer::Init()

--- a/engine/audio/audiomixer.h
+++ b/engine/audio/audiomixer.h
@@ -44,3 +44,18 @@ private:
 };
 
 } // namespace pong
+
+namespace pong::audio
+{
+
+extern AudioMixer* gAudioMixer;
+
+void PlaySound(const Sound& sound);
+void PlaySound(const Sound& sound, const glm::vec3& position);
+
+float GetVolume();
+void SetVolume(float volume);
+bool GetSpatialAudioEnabled();
+void SetSpatialAudioEnabled(bool enabled);
+
+}

--- a/engine/audio/audiomixer.h
+++ b/engine/audio/audiomixer.h
@@ -50,6 +50,9 @@ namespace pong::audio
 
 extern AudioMixer* gAudioMixer;
 
+AudioMixer* GetAudioMixerInstance();
+void SetAudioMixerInstance(AudioMixer* audioMixer);
+
 void PlaySound(const Sound& sound);
 void PlaySound(const Sound& sound, const glm::vec3& position);
 

--- a/engine/audio/audiomixer.h
+++ b/engine/audio/audiomixer.h
@@ -45,7 +45,7 @@ private:
 
 } // namespace pong
 
-namespace pong::audio
+namespace pong::globals::audio
 {
 
 extern AudioMixer* gAudioMixer;
@@ -61,4 +61,4 @@ void SetVolume(float volume);
 bool GetSpatialAudioEnabled();
 void SetSpatialAudioEnabled(bool enabled);
 
-}
+} // namespace pong::globals::audio

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -18,9 +18,9 @@ void Engine::Init(const std::string& configPath)
 {
     ASSERT(Config::LoadConfig(configPath));
 
-    application::SetWindowInstance(&mApplicationWindow);
-    input::SetInputInstance(&mInput);
-    game::SetPongInstance(&mPong);
+    globals::application::SetWindowInstance(&mApplicationWindow);
+    globals::input::SetInputInstance(&mInput);
+    globals::game::SetPongInstance(&mPong);
 
     mApplicationWindow.Init();
     mApplicationWindow.SetWindowTitle("Pong");
@@ -115,7 +115,7 @@ void Engine::Cleanup()
     mApplicationWindow.Cleanup();
 }
 
-int Engine::GetTargetFPS()
+int Engine::GetTargetFPS() const
 {
     return mTargetFPS;
 }
@@ -135,7 +135,7 @@ void Engine::QuitApplication()
 
 } // namespace pong
 
-namespace pong::engine
+namespace pong::globals::engine
 {
 
 Engine* gEngine { nullptr };
@@ -166,4 +166,4 @@ void QuitApplication()
     GetEngineInstance()->QuitApplication();
 }
 
-} // namespace pong::engine
+} // namespace pong::globals::engine

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -142,17 +142,17 @@ void SetEngineInstance(Engine* engine)
 
 int GetTargetFPS()
 {
-    return gEngine->GetTargetFPS();
+    return GetEngineInstance()->GetTargetFPS();
 }
 
 void SetTargetFPS(const int fps)
 {
-    gEngine->SetTargetFPS(fps);
+    GetEngineInstance()->SetTargetFPS(fps);
 }
 
 void QuitApplication()
 {
-    gEngine->QuitApplication();
+    GetEngineInstance()->QuitApplication();
 }
 
 } // namespace pong::engine

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -24,7 +24,10 @@ void Engine::Init(const std::string& configPath)
     ApplicationWindow::SetWindowTitle("Pong");
     ApplicationWindow::SetWindowIcon(Config::GetValue<std::string>("window_icon"));
     Renderer::Init();
-    Input::Init();
+
+    input::SetInputInstance(&mInput);
+
+    mInput.Init();
 
     const auto targetFPSJson = Config::GetJsonValue("target_fps");
     if (targetFPSJson.has_value() && targetFPSJson.value().is_number_integer())
@@ -132,6 +135,7 @@ Engine* gEngine { nullptr };
 
 Engine* GetEngineInstance()
 {
+    ASSERT(gEngine != nullptr);
     return gEngine;
 }
 

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -20,12 +20,13 @@ void Engine::Init(const std::string& configPath)
 
     application::SetWindowInstance(&mApplicationWindow);
     input::SetInputInstance(&mInput);
+    game::SetPongInstance(&mPong);
 
     mApplicationWindow.Init();
     mApplicationWindow.SetWindowTitle("Pong");
     mApplicationWindow.SetWindowIcon(Config::GetValue<std::string>("window_icon"));
-    mRenderer.Init();
 
+    mRenderer.Init(&mPong.GetComponentManager());
 
     mInput.Init();
 
@@ -48,8 +49,7 @@ void Engine::Init(const std::string& configPath)
         LogInfo("Target FPS not specified or invalid. Using refresh rate.");
     }
 
-    Pong::mRenderer = &mRenderer;
-    Pong::Init();
+    mPong.Init();
 }
 
 void Engine::RunApplication()
@@ -64,7 +64,8 @@ void Engine::RunApplication()
             frameCount++;
 
             mRenderer.Clear();
-            Pong::GameLoop();
+            mPong.GameLoop();
+            mRenderer.DrawAll();
             mApplicationWindow.SwapBuffers();
         }
     }
@@ -104,7 +105,7 @@ void Engine::Cleanup()
         Config::SaveConfig();
     }
 
-    Pong::Cleanup();
+    mPong.Cleanup();
     mRenderer.Cleanup();
     mApplicationWindow.Cleanup();
 }

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -14,18 +14,18 @@
 namespace pong
 {
 
-Engine gEngine {};
-
 void Engine::Init(const std::string& configPath)
 {
     ASSERT(Config::LoadConfig(configPath));
 
+    application::SetWindowInstance(&mApplicationWindow);
+    input::SetInputInstance(&mInput);
+
     mApplicationWindow.Init();
     mApplicationWindow.SetWindowTitle("Pong");
     mApplicationWindow.SetWindowIcon(Config::GetValue<std::string>("window_icon"));
-    Renderer::Init();
+    mRenderer.Init();
 
-    input::SetInputInstance(&mInput);
 
     mInput.Init();
 
@@ -48,6 +48,7 @@ void Engine::Init(const std::string& configPath)
         LogInfo("Target FPS not specified or invalid. Using refresh rate.");
     }
 
+    Pong::mRenderer = &mRenderer;
     Pong::Init();
 }
 
@@ -62,7 +63,7 @@ void Engine::RunApplication()
         {
             frameCount++;
 
-            Renderer::Clear();
+            mRenderer.Clear();
             Pong::GameLoop();
             mApplicationWindow.SwapBuffers();
         }
@@ -104,7 +105,7 @@ void Engine::Cleanup()
     }
 
     Pong::Cleanup();
-    Renderer::Cleanup();
+    mRenderer.Cleanup();
     mApplicationWindow.Cleanup();
 }
 

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -14,11 +14,7 @@
 namespace pong
 {
 
-Engine& Engine::GetInstance()
-{
-    static Engine instance;
-    return instance;
-}
+Engine gEngine {};
 
 void Engine::Init(const std::string& configPath)
 {
@@ -111,14 +107,14 @@ void Engine::Cleanup()
 
 int Engine::GetTargetFPS()
 {
-    return GetInstance().mTargetFPS;
+    return mTargetFPS;
 }
 
 void Engine::SetTargetFPS(int fps)
 {
     ASSERT(fps > 0);
-    GetInstance().mTargetFPS = fps;
-    GetInstance().mTimePerFrame = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::seconds(1)) / GetInstance().mTargetFPS;
+    mTargetFPS = fps;
+    mTimePerFrame = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::seconds(1)) / mTargetFPS;
     Config::SetValue("target_fps", fps);
 }
 
@@ -128,3 +124,35 @@ void Engine::QuitApplication()
 }
 
 } // namespace pong
+
+namespace pong::engine
+{
+
+Engine* gEngine { nullptr };
+
+Engine* GetEngineInstance()
+{
+    return gEngine;
+}
+
+void SetEngineInstance(Engine* engine)
+{
+    gEngine = engine;
+}
+
+int GetTargetFPS()
+{
+    return gEngine->GetTargetFPS();
+}
+
+void SetTargetFPS(const int fps)
+{
+    gEngine->SetTargetFPS(fps);
+}
+
+void QuitApplication()
+{
+    gEngine->QuitApplication();
+}
+
+} // namespace pong::engine

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -20,9 +20,9 @@ void Engine::Init(const std::string& configPath)
 {
     ASSERT(Config::LoadConfig(configPath));
 
-    ApplicationWindow::Init();
-    ApplicationWindow::SetWindowTitle("Pong");
-    ApplicationWindow::SetWindowIcon(Config::GetValue<std::string>("window_icon"));
+    mApplicationWindow.Init();
+    mApplicationWindow.SetWindowTitle("Pong");
+    mApplicationWindow.SetWindowIcon(Config::GetValue<std::string>("window_icon"));
     Renderer::Init();
 
     input::SetInputInstance(&mInput);
@@ -44,7 +44,7 @@ void Engine::Init(const std::string& configPath)
     }
     else
     {
-        ApplicationWindow::SetVSync(true);
+        mApplicationWindow.SetVSync(true);
         LogInfo("Target FPS not specified or invalid. Using refresh rate.");
     }
 
@@ -56,7 +56,7 @@ void Engine::RunApplication()
     int frameCount = 0;
     const auto windowStartTime = std::chrono::high_resolution_clock::now();
 
-    while (!ApplicationWindow::ShouldClose())
+    while (!mApplicationWindow.ShouldClose())
     {
         if (IsNextFrameReady())
         {
@@ -64,7 +64,7 @@ void Engine::RunApplication()
 
             Renderer::Clear();
             Pong::GameLoop();
-            ApplicationWindow::SwapBuffers();
+            mApplicationWindow.SwapBuffers();
         }
     }
 
@@ -78,7 +78,7 @@ void Engine::RunApplication()
 
 bool Engine::IsNextFrameReady()
 {
-    if (ApplicationWindow::IsVSyncActive())
+    if (mApplicationWindow.IsVSyncActive())
     {
         mLastFrameTimeStamp = std::chrono::high_resolution_clock::now();
         return true;
@@ -105,7 +105,7 @@ void Engine::Cleanup()
 
     Pong::Cleanup();
     Renderer::Cleanup();
-    ApplicationWindow::Cleanup();
+    mApplicationWindow.Cleanup();
 }
 
 int Engine::GetTargetFPS()
@@ -123,7 +123,7 @@ void Engine::SetTargetFPS(int fps)
 
 void Engine::QuitApplication()
 {
-    ApplicationWindow::SetShouldCloseWindow();
+    mApplicationWindow.SetShouldCloseWindow();
 }
 
 } // namespace pong

--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -64,7 +64,12 @@ void Engine::RunApplication()
             frameCount++;
 
             mRenderer.Clear();
+
             mPong.GameLoop();
+            // Done after game loop because input callbacks are done in glfwPollEvents after this loop.
+            // So this effectively keeps the values from the new frame before updated from pressed -> held
+            mInput.Update();
+
             mRenderer.DrawAll();
             mApplicationWindow.SwapBuffers();
         }

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -27,7 +27,8 @@ public:
 private:
     bool IsNextFrameReady();
 
-    Input mInput { Renderer::GetInstance(), ApplicationWindow::GetInstance() };
+    ApplicationWindow mApplicationWindow {};
+    Input mInput { Renderer::GetInstance(), mApplicationWindow };
 
     int mTargetFPS { 60 };
     std::chrono::nanoseconds mTimePerFrame { 0 };

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -27,8 +27,9 @@ public:
 private:
     bool IsNextFrameReady();
 
+    Renderer mRenderer {};
     ApplicationWindow mApplicationWindow {};
-    Input mInput { Renderer::GetInstance(), mApplicationWindow };
+    Input mInput { mRenderer, mApplicationWindow };
 
     int mTargetFPS { 60 };
     std::chrono::nanoseconds mTimePerFrame { 0 };

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -11,25 +11,19 @@ namespace pong
 class Engine
 {
 public:
-    static Engine& GetInstance();
+    Engine() = default;
+    ~Engine() = default;
 
     void Init(const std::string& configPath);
     void RunApplication();
     void Cleanup();
 
-    static int GetTargetFPS();
-    static void SetTargetFPS(int fps);
+    int GetTargetFPS();
+    void SetTargetFPS(int fps);
 
-    static void QuitApplication();
+    void QuitApplication();
 
 private:
-    Engine() = default;
-    ~Engine() = default;
-    Engine(const Engine&) = delete;
-    Engine(Engine&&) = delete;
-    Engine& operator=(const Engine&) = delete;
-    Engine& operator=(Engine&&) = delete;
-
     bool IsNextFrameReady();
 
     int mTargetFPS { 60 };
@@ -38,3 +32,17 @@ private:
 };
 
 } // namespace pong
+
+namespace pong::engine
+{
+
+extern Engine* gEngine;
+
+Engine* GetEngineInstance();
+void SetEngineInstance(Engine* engine);
+
+int GetTargetFPS();
+void SetTargetFPS(const int fps);
+void QuitApplication();
+
+} // namespace pong::engine

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -2,6 +2,7 @@
 
 #include "applicationwindow.h"
 #include "input.h"
+#include "pong.h"
 #include "renderer.h"
 
 #include <string>
@@ -30,6 +31,7 @@ private:
     Renderer mRenderer {};
     ApplicationWindow mApplicationWindow {};
     Input mInput { mRenderer, mApplicationWindow };
+    Pong mPong {};
 
     int mTargetFPS { 60 };
     std::chrono::nanoseconds mTimePerFrame { 0 };

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -20,7 +20,7 @@ public:
     void RunApplication();
     void Cleanup();
 
-    int GetTargetFPS();
+    int GetTargetFPS() const;
     void SetTargetFPS(int fps);
 
     void QuitApplication();
@@ -40,7 +40,7 @@ private:
 
 } // namespace pong
 
-namespace pong::engine
+namespace pong::globals::engine
 {
 
 extern Engine* gEngine;
@@ -52,4 +52,4 @@ int GetTargetFPS();
 void SetTargetFPS(const int fps);
 void QuitApplication();
 
-} // namespace pong::engine
+} // namespace pong::globals::engine

--- a/engine/engine.h
+++ b/engine/engine.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "applicationwindow.h"
+#include "input.h"
 #include "renderer.h"
 
 #include <string>
@@ -25,6 +26,8 @@ public:
 
 private:
     bool IsNextFrameReady();
+
+    Input mInput { Renderer::GetInstance(), ApplicationWindow::GetInstance() };
 
     int mTargetFPS { 60 };
     std::chrono::nanoseconds mTimePerFrame { 0 };

--- a/engine/graphics/font.cpp
+++ b/engine/graphics/font.cpp
@@ -81,10 +81,10 @@ FontCharacter Font::LoadCharacter(const char character)
     const float spaceAboveCharPixels = mAscent + yCoord1;
     fontCharacter.mYOffset = spaceAboveCharPixels;
 
-    fontCharacter.mBitmap.mPixels.resize(charWidth * charHeight);
-
     if (character != '\n')
     {
+        fontCharacter.mBitmap.mPixels.resize(charWidth * charHeight);
+
         // Since this uses a single character for each texture, stride is just the pixel width of the character
         const int kStride = charWidth;
         stbtt_MakeCodepointBitmap(&mFontInfo, fontCharacter.mBitmap.mPixels.data(),
@@ -95,12 +95,12 @@ FontCharacter Font::LoadCharacter(const char character)
         fontCharacter.mBitmap.mWidth = charWidth;
         fontCharacter.mBitmap.mHeight = charHeight;
         fontCharacter.mBitmap.mComponents = 1;
-    }
 
-    // Bitmap returned is alpha only, and stored bottom left pixel first
-    // Convert to RGBA and flip it for OpenGL
-    const auto rgbTexture = image::ConvertAlphaImageToRGBA(fontCharacter.mBitmap);
-    fontCharacter.mBitmap = image::FlipImageVertically(rgbTexture);
+        // Bitmap returned is alpha only, and stored bottom left pixel first
+        // Convert to RGBA and flip it for OpenGL
+        const auto rgbTexture = image::ConvertAlphaImageToRGBA(fontCharacter.mBitmap);
+        fontCharacter.mBitmap = image::FlipImageVertically(rgbTexture);
+    }
 
     mCharacters[character] = fontCharacter;
     return fontCharacter;
@@ -170,7 +170,11 @@ FontCharacter Font::GetCharacter(const char character)
     auto it = mCharacters.find(character);
     if (it == mCharacters.end())
     {
-        LogDebug("Character {} not found in cache, loading it", character);
+        std::string characterStr {};
+        if (character == '\n')
+            characterStr = "\\n";
+
+        LogDebug("Character {} not found in cache, loading it", characterStr);
         return LoadCharacter(character);
     }
 

--- a/engine/input.cpp
+++ b/engine/input.cpp
@@ -29,9 +29,9 @@ void Input::Init()
     }
 
     GLFWwindow* glfwWindow = mWindow.GetWindow();
-    glfwSetKeyCallback(glfwWindow, input::KeyCallback);
-    glfwSetCursorPosCallback(glfwWindow, input::MousePositionCallback);
-    glfwSetMouseButtonCallback(glfwWindow, input::MouseButtonCallback);
+    glfwSetKeyCallback(glfwWindow, globals::input::KeyCallback);
+    glfwSetCursorPosCallback(glfwWindow, globals::input::MousePositionCallback);
+    glfwSetMouseButtonCallback(glfwWindow, globals::input::MouseButtonCallback);
 }
 
 void Input::Update()
@@ -64,17 +64,17 @@ void Input::KeyCallback(GLFWwindow* /*window*/, int key, int /*scancode*/, int a
     mKeys[key] = (action == GLFW_PRESS || action == GLFW_REPEAT) ? InputState::Pressed : InputState::Released;
 }
 
-InputState Input::GetKeyState(unsigned int keycode)
+InputState Input::GetKeyState(unsigned int keycode) const
 {
     return mKeys[keycode];
 }
 
-bool Input::CheckKeyDown(unsigned int keycode)
+bool Input::CheckKeyDown(unsigned int keycode) const
 {
     return mKeys[keycode] == InputState::Pressed || mKeys[keycode] == InputState::Held;
 }
 
-bool Input::CheckKeyUp(unsigned int keycode)
+bool Input::CheckKeyUp(unsigned int keycode) const
 {
     return mKeys[keycode] == InputState::Released || mKeys[keycode] == InputState::NotPressed;
 }
@@ -84,17 +84,17 @@ void Input::MouseButtonCallback(GLFWwindow* /*window*/, int button, int action, 
     mMouseButtons[button] = (action == GLFW_PRESS) ? InputState::Pressed : InputState::Released;
 }
 
-InputState Input::GetMouseButtonState(unsigned int button)
+InputState Input::GetMouseButtonState(unsigned int button) const
 {
     return mMouseButtons[button];
 }
 
-bool Input::CheckMouseButtonDown(unsigned int button)
+bool Input::CheckMouseButtonDown(unsigned int button) const
 {
     return mMouseButtons[button] == InputState::Pressed || mMouseButtons[button] == InputState::Held;
 }
 
-bool Input::CheckMouseButtonUp(unsigned int button)
+bool Input::CheckMouseButtonUp(unsigned int button) const
 {
     return mMouseButtons[button] == InputState::Released || mMouseButtons[button] == InputState::NotPressed;
 }
@@ -120,14 +120,14 @@ void Input::MousePositionCallback(GLFWwindow* /*window*/, double xPos, double yP
 }
 
 // Mouse position converted to screen/world coordinates
-glm::vec3 Input::GetMousePosition()
+glm::vec3 Input::GetMousePosition() const
 {
     return mMousePosition;
 }
 
 } // namespace pong
 
-namespace pong::input
+namespace pong::globals::input
 {
 
 Input* gInput = nullptr;
@@ -193,4 +193,4 @@ glm::vec3 GetMousePosition()
     return GetInputInstance()->GetMousePosition();
 }
 
-} // namespace pong::input
+} // namespace pong::globals::input

--- a/engine/input.cpp
+++ b/engine/input.cpp
@@ -115,8 +115,8 @@ void Input::MousePositionCallback(GLFWwindow* /*window*/, double xPos, double yP
     const float mouseWindowY = (y <= halfWindowHeight) ?
         (halfWindowHeight - y) * 2.0f : (y - halfWindowHeight) * -2.0f;
 
-    mMousePosition.x = mouseWindowX / windowWidth * Renderer::GetXCoordMax();
-    mMousePosition.y = mouseWindowY / windowHeight * Renderer::GetYCoordMax();
+    mMousePosition.x = mouseWindowX / windowWidth * mRenderer.GetXCoordMax();
+    mMousePosition.y = mouseWindowY / windowHeight * mRenderer.GetYCoordMax();
 }
 
 // Mouse position converted to screen/world coordinates

--- a/engine/input.cpp
+++ b/engine/input.cpp
@@ -10,11 +10,11 @@
 namespace pong
 {
 
-// All keys are intalized to false, for not pressed
-std::array<InputState, GLFW_KEY_LAST + 1> Input::mKeys {};
-std::array<InputState, GLFW_MOUSE_BUTTON_LAST + 1> Input::mMouseButtons {};
-// Initalize way outside the screen so it does not trigger anything before it should
-glm::vec3 Input::mMousePosition { std::numeric_limits<float>::max() };
+Input::Input(Renderer& renderer, ApplicationWindow& window) :
+    mRenderer(renderer),
+    mWindow(window)
+{
+}
 
 void Input::Init()
 {
@@ -28,10 +28,10 @@ void Input::Init()
         inputVal = InputState::NotPressed;
     }
 
-    GLFWwindow* glfwWindow = ApplicationWindow::GetInstance().GetWindow();
-    glfwSetKeyCallback(glfwWindow, Input::KeyCallback);
-    glfwSetCursorPosCallback(glfwWindow, Input::MousePositionCallback);
-    glfwSetMouseButtonCallback(glfwWindow, Input::MouseButtonCallback);
+    GLFWwindow* glfwWindow = mWindow.GetWindow();
+    glfwSetKeyCallback(glfwWindow, input::KeyCallback);
+    glfwSetCursorPosCallback(glfwWindow, input::MousePositionCallback);
+    glfwSetMouseButtonCallback(glfwWindow, input::MouseButtonCallback);
 }
 
 void Input::Update()
@@ -104,8 +104,8 @@ void Input::MousePositionCallback(GLFWwindow* /*window*/, double xPos, double yP
     const float x = static_cast<float>(xPos);
     const float y = static_cast<float>(yPos);
 
-    const int windowWidth = ApplicationWindow::GetScreenWidth();
-    const int windowHeight = ApplicationWindow::GetScreenHeight();
+    const int windowWidth = mWindow.GetScreenWidth();
+    const int windowHeight = mWindow.GetScreenHeight();
     const float halfWindowWidth = windowWidth / 2.0f;
     const float halfWindowHeight = windowHeight / 2.0f;
 
@@ -126,3 +126,77 @@ glm::vec3 Input::GetMousePosition()
 }
 
 } // namespace pong
+
+namespace pong::input
+{
+
+Input* gInput = nullptr;
+
+Input* GetInputInstance()
+{
+    ASSERT(gInput != nullptr);
+    return gInput;
+}
+
+void SetInputInstance(Input* input)
+{
+    gInput = input;
+}
+
+// Remove this ------------
+void Update()
+{
+    GetInputInstance()->Update();
+}
+
+void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods)
+{
+    GetInputInstance()->KeyCallback(window, key, scancode, action, mods);
+}
+
+void MouseButtonCallback(GLFWwindow* window, int button, int action, int mods)
+{
+    GetInputInstance()->MouseButtonCallback(window, button, action, mods);
+}
+
+void MousePositionCallback(GLFWwindow* window, double xpos, double ypos)
+{
+    GetInputInstance()->MousePositionCallback(window, xpos, ypos);
+}
+
+InputState GetKeyState(unsigned int keycode)
+{
+    return GetInputInstance()->GetKeyState(keycode);
+}
+
+bool CheckKeyDown(unsigned int keycode)
+{
+    return GetInputInstance()->CheckKeyDown(keycode);
+}
+
+bool CheckKeyUp(unsigned int keycode)
+{
+    return GetInputInstance()->CheckKeyUp(keycode);
+}
+
+InputState GetMouseButtonState(unsigned int button)
+{
+    return GetInputInstance()->GetMouseButtonState(button);
+}
+
+bool CheckMouseButtonDown(unsigned int button)
+{
+    return GetInputInstance()->CheckMouseButtonDown(button);
+}
+
+bool CheckMouseButtonUp(unsigned int button)
+{
+    return GetInputInstance()->CheckMouseButtonUp(button);
+}
+
+glm::vec3 GetMousePosition()
+{
+    return GetInputInstance()->GetMousePosition();
+}
+
+} // namespace pong::input

--- a/engine/input.cpp
+++ b/engine/input.cpp
@@ -143,12 +143,6 @@ void SetInputInstance(Input* input)
     gInput = input;
 }
 
-// Remove this ------------
-void Update()
-{
-    GetInputInstance()->Update();
-}
-
 void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods)
 {
     GetInputInstance()->KeyCallback(window, key, scancode, action, mods);

--- a/engine/input.h
+++ b/engine/input.h
@@ -30,17 +30,17 @@ public:
     void Update();
 
     void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
-    InputState GetKeyState(unsigned int keycode);
-    bool CheckKeyDown(unsigned int keycode);
-    bool CheckKeyUp(unsigned int keycode);
+    InputState GetKeyState(unsigned int keycode) const;
+    bool CheckKeyDown(unsigned int keycode) const;
+    bool CheckKeyUp(unsigned int keycode) const;
 
     void MouseButtonCallback(GLFWwindow* window, int button, int action, int mods);
-    InputState GetMouseButtonState(unsigned int button);
-    bool CheckMouseButtonDown(unsigned int button);
-    bool CheckMouseButtonUp(unsigned int button);
+    InputState GetMouseButtonState(unsigned int button) const;
+    bool CheckMouseButtonDown(unsigned int button) const;
+    bool CheckMouseButtonUp(unsigned int button) const;
 
     void MousePositionCallback(GLFWwindow* window, double xpos, double ypos);
-    glm::vec3 GetMousePosition();
+    glm::vec3 GetMousePosition() const;
 
 private:
     Renderer& mRenderer;
@@ -53,7 +53,7 @@ private:
 
 } // namespace pong
 
-namespace pong::input
+namespace pong::globals::input
 {
 
 extern Input* gInput;
@@ -75,4 +75,4 @@ bool CheckMouseButtonUp(unsigned int button);
 
 glm::vec3 GetMousePosition();
 
-} // namespace pong::input
+} // namespace pong::globals::input

--- a/engine/input.h
+++ b/engine/input.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "applicationwindow.h"
+#include "renderer.h"
+
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
 #include <glm/glm.hpp>
@@ -21,26 +24,56 @@ enum class InputState
 class Input
 {
 public:
-    static void Init();
-    static void Update();
+    Input(Renderer& renderer, ApplicationWindow& window);
 
-    static void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
-    static InputState GetKeyState(unsigned int keycode);
-    static bool CheckKeyDown(unsigned int keycode);
-    static bool CheckKeyUp(unsigned int keycode);
+    void Init();
+    void Update();
 
-    static void MouseButtonCallback(GLFWwindow* window, int button, int action, int mods);
-    static InputState GetMouseButtonState(unsigned int button);
-    static bool CheckMouseButtonDown(unsigned int button);
-    static bool CheckMouseButtonUp(unsigned int button);
+    void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
+    InputState GetKeyState(unsigned int keycode);
+    bool CheckKeyDown(unsigned int keycode);
+    bool CheckKeyUp(unsigned int keycode);
 
-    static void MousePositionCallback(GLFWwindow* window, double xpos, double ypos);
-    static glm::vec3 GetMousePosition();
+    void MouseButtonCallback(GLFWwindow* window, int button, int action, int mods);
+    InputState GetMouseButtonState(unsigned int button);
+    bool CheckMouseButtonDown(unsigned int button);
+    bool CheckMouseButtonUp(unsigned int button);
+
+    void MousePositionCallback(GLFWwindow* window, double xpos, double ypos);
+    glm::vec3 GetMousePosition();
 
 private:
-    static std::array<InputState, GLFW_KEY_LAST + 1> mKeys;
-    static std::array<InputState, GLFW_MOUSE_BUTTON_LAST + 1> mMouseButtons;
-    static glm::vec3 mMousePosition;
+    Renderer& mRenderer;
+    ApplicationWindow& mWindow;
+    std::array<InputState, GLFW_KEY_LAST + 1> mKeys {};
+    std::array<InputState, GLFW_MOUSE_BUTTON_LAST + 1> mMouseButtons {};
+    // Initalize way outside the screen so it does not trigger anything before it should
+    glm::vec3 mMousePosition { std::numeric_limits<float>::max() };
 };
 
 } // namespace pong
+
+namespace pong::input
+{
+
+extern Input* gInput;
+
+Input* GetInputInstance();
+void SetInputInstance(Input* input);
+
+void Update();
+void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
+void MouseButtonCallback(GLFWwindow* window, int button, int action, int mods);
+void MousePositionCallback(GLFWwindow* window, double xpos, double ypos);
+
+InputState GetKeyState(unsigned int keycode);
+bool CheckKeyDown(unsigned int keycode);
+bool CheckKeyUp(unsigned int keycode);
+
+InputState GetMouseButtonState(unsigned int button);
+bool CheckMouseButtonDown(unsigned int button);
+bool CheckMouseButtonUp(unsigned int button);
+
+glm::vec3 GetMousePosition();
+
+} // namespace pong::input

--- a/engine/input.h
+++ b/engine/input.h
@@ -61,7 +61,6 @@ extern Input* gInput;
 Input* GetInputInstance();
 void SetInputInstance(Input* input);
 
-void Update();
 void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
 void MouseButtonCallback(GLFWwindow* window, int button, int action, int mods);
 void MousePositionCallback(GLFWwindow* window, double xpos, double ypos);

--- a/engine/pong.cpp
+++ b/engine/pong.cpp
@@ -48,9 +48,8 @@ Timer& Pong::GetTimer()
 
 void Pong::Init()
 {
-    timer::gTimer = &GetInstance().mTimer;
-    audio::gAudioMixer = &GetInstance().mAudioMixer;
-
+    timer::SetTimerInstance(&GetInstance().mTimer);
+    audio::SetAudioMixerInstance(&GetInstance().mAudioMixer);
 
     GetInstance().GetAudioMixer().Init();
     GetInstance().mFontBank.LoadFonts();

--- a/engine/pong.cpp
+++ b/engine/pong.cpp
@@ -48,12 +48,16 @@ Timer& Pong::GetTimer()
 
 void Pong::Init()
 {
+    timer::gTimer = &GetInstance().mTimer;
+    audio::gAudioMixer = &GetInstance().mAudioMixer;
+
+
     GetInstance().GetAudioMixer().Init();
     GetInstance().mFontBank.LoadFonts();
     GetInstance().mSceneLoader.PreLoadScenes();
     GetInstance().GetTimer().Init();
 
-    GetInstance().LoadScene(Config::GetValue<std::string>("starting_scene"));
+    GetInstance().LoadScene(Config::GetValue<std::string>("starting_scene", "Title"));
 }
 
 void Pong::GameLoop()

--- a/engine/pong.cpp
+++ b/engine/pong.cpp
@@ -81,7 +81,7 @@ void Pong::GameLoop()
 
     // Done last because input callbacks are done in glfwPollEvents after this loop.
     // So this effectively keeps the values from the new frame before updated from pressed -> held
-    Input::Update();
+    input::Update();
 }
 
 void Pong::Reset()

--- a/engine/pong.cpp
+++ b/engine/pong.cpp
@@ -68,10 +68,6 @@ void Pong::GameLoop()
     {
         behavior->OnUpdate();
     }
-
-    // Done last because input callbacks are done in glfwPollEvents after this loop.
-    // So this effectively keeps the values from the new frame before updated from pressed -> held
-    input::Update();
 }
 
 void Pong::Reset()

--- a/engine/pong.cpp
+++ b/engine/pong.cpp
@@ -10,6 +10,8 @@
 namespace pong
 {
 
+Renderer* Pong::mRenderer { nullptr };
+
 Pong& Pong::GetInstance()
 {
     static Pong instance;
@@ -77,7 +79,7 @@ void Pong::GameLoop()
         behavior->OnUpdate();
     }
 
-    Renderer::DrawAll();
+    mRenderer->DrawAll();
 
     // Done last because input callbacks are done in glfwPollEvents after this loop.
     // So this effectively keeps the values from the new frame before updated from pressed -> held

--- a/engine/pong.cpp
+++ b/engine/pong.cpp
@@ -42,7 +42,7 @@ Timer& Pong::GetTimer()
 void Pong::Init()
 {
     timer::SetTimerInstance(&mTimer);
-    audio::SetAudioMixerInstance(&mAudioMixer);
+    globals::audio::SetAudioMixerInstance(&mAudioMixer);
 
     GetAudioMixer().Init();
     mFontBank.LoadFonts();
@@ -140,7 +140,7 @@ GameObject* Pong::FindGameObjectByName(const std::string& name)
 
 } // namespace pong
 
-namespace pong::game
+namespace pong::globals::game
 {
 
 Pong* gPong { nullptr };
@@ -165,4 +165,4 @@ void LoadSceneNext(const std::string& sceneName)
     GetPongInstance()->LoadSceneNext(sceneName);
 }
 
-} // namespace pong::game
+} // namespace pong::globals::game

--- a/engine/pong.h
+++ b/engine/pong.h
@@ -97,7 +97,7 @@ private:
 
 } // namespace pong
 
-namespace pong::game
+namespace pong::globals::game
 {
 
 extern Pong* gPong;
@@ -114,4 +114,4 @@ T* FindComponentOfType()
 GameObject* FindGameObjectByName(const std::string& name);
 void LoadSceneNext(const std::string& sceneName);
 
-} // namespace pong::game
+} // namespace pong::globals::game

--- a/engine/pong.h
+++ b/engine/pong.h
@@ -6,6 +6,7 @@
 #include "componentmanager.h"
 #include "fontbank.h"
 #include "gameobject.h"
+#include "renderer.h"
 #include "sceneloader.h"
 #include "text.h"
 #include "timer.h"
@@ -68,6 +69,9 @@ public:
     }
 
     static GameObject* FindGameObjectByName(const std::string& name);
+
+    // Remove this
+    static Renderer* mRenderer;
 
     CollisionManager& GetCollisionManager();
     ComponentManager& GetComponentManager();

--- a/engine/pong.h
+++ b/engine/pong.h
@@ -6,6 +6,7 @@
 #include "componentmanager.h"
 #include "fontbank.h"
 #include "gameobject.h"
+#include "input.h"
 #include "sceneloader.h"
 #include "text.h"
 #include "timer.h"

--- a/engine/pong.h
+++ b/engine/pong.h
@@ -6,7 +6,6 @@
 #include "componentmanager.h"
 #include "fontbank.h"
 #include "gameobject.h"
-#include "renderer.h"
 #include "sceneloader.h"
 #include "text.h"
 #include "timer.h"
@@ -26,18 +25,19 @@ namespace pong
 class Pong
 {
 public:
-    static Pong& GetInstance();
+    Pong() = default;
+    ~Pong() = default;
 
-    static void Init();
-    static void GameLoop();
-    static void Reset();
-    static void Cleanup();
+    void Init();
+    void GameLoop();
+    void Reset();
+    void Cleanup();
 
-    static void LoadSceneNext(const std::string& sceneName);
+    void LoadSceneNext(const std::string& sceneName);
 
     // Returns the first component of type T found in the scene
     template<typename T, typename = std::enable_if_t<std::is_base_of_v<BaseComponent, T> && !std::is_base_of_v<Behavior, T>>>
-    static T* FindComponentOfType()
+    T* FindComponentOfType()
     {
         const std::vector<std::unique_ptr<T>>& components = T::GetComponents();
 
@@ -51,7 +51,7 @@ public:
 
     // Returns the first component of type T found in the scene
     template<typename T, typename = std::enable_if_t<std::is_base_of_v<Behavior, T>>, typename = void>
-    static T* FindComponentOfType()
+    T* FindComponentOfType()
     {
         // Since behaviors are the only components meant to be overridden, they are stored in a Behavior vector
         // getting a specific behavior class from the vector is done by comparing the behavior Id
@@ -68,10 +68,7 @@ public:
         return nullptr;
     }
 
-    static GameObject* FindGameObjectByName(const std::string& name);
-
-    // Remove this
-    static Renderer* mRenderer;
+    GameObject* FindGameObjectByName(const std::string& name);
 
     CollisionManager& GetCollisionManager();
     ComponentManager& GetComponentManager();
@@ -81,13 +78,6 @@ public:
     Timer& GetTimer();
 
 private:
-    Pong() = default;
-    Pong(const Pong&) = delete;
-    Pong& operator=(const Pong&) = delete;
-    Pong(Pong&&) = delete;
-    Pong& operator=(Pong&&) = delete;
-    ~Pong() = default;
-
     void LoadScene(const std::string& sceneName);
 
     std::vector<std::unique_ptr<GameObject>> mGameObjects {};
@@ -105,3 +95,22 @@ private:
 };
 
 } // namespace pong
+
+namespace pong::game
+{
+
+extern Pong* gPong;
+
+Pong* GetPongInstance();
+void SetPongInstance(Pong* pong);
+
+template<typename T>
+T* FindComponentOfType()
+{
+    return GetPongInstance()->FindComponentOfType<T>();
+}
+
+GameObject* FindGameObjectByName(const std::string& name);
+void LoadSceneNext(const std::string& sceneName);
+
+} // namespace pong::game

--- a/engine/renderer.cpp
+++ b/engine/renderer.cpp
@@ -24,12 +24,6 @@ namespace pong
 static constexpr float SCREEN_X_COORDS = 1280;
 static constexpr float SCREEN_Y_COORDS = 960;
 
-Renderer& Renderer::GetInstance()
-{
-    static Renderer sInstance;
-    return sInstance;
-}
-
 void Renderer::Init()
 {
     if (glewInit() != GLEW_OK)
@@ -70,13 +64,13 @@ void Renderer::Init()
         ASSERT(false);
     }
 
-    GetInstance().mShader = std::make_unique<Shader>(shaderPath);
+    mShader = std::make_unique<Shader>(shaderPath);
 }
 
 void Renderer::Cleanup()
 {
-    GetInstance().mShader.reset();
-    GetInstance().mShader = nullptr;
+    mShader.reset();
+    mShader = nullptr;
 }
 
 void Renderer::DrawAll()
@@ -135,7 +129,7 @@ void Renderer::Draw(const VertexArray& va, const IndexBuffer& ib,
     va.Bind();
     ib.Bind();
 
-    GetInstance().mShader->Bind();
+    mShader->Bind();
     const glm::mat4 proj = glm::ortho(-SCREEN_X_COORDS, SCREEN_X_COORDS, -SCREEN_Y_COORDS, SCREEN_Y_COORDS, -1.0f, 1.0f);
     const glm::mat4 view = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f));
     const glm::mat4 model = glm::translate(glm::mat4(1.0f), position);
@@ -143,9 +137,9 @@ void Renderer::Draw(const VertexArray& va, const IndexBuffer& ib,
     const glm::mat4 mvp = proj * view * model;
 
     texture.Bind(0);
-    GetInstance().mShader->SetUniform1i("uTexture", 0);
-    GetInstance().mShader->SetUniform4f("uColor", color.r, color.g, color.b, color.a);
-    GetInstance().mShader->SetUniformMat4f("uMVP", mvp);
+    mShader->SetUniform1i("uTexture", 0);
+    mShader->SetUniform4f("uColor", color.r, color.g, color.b, color.a);
+    mShader->SetUniformMat4f("uMVP", mvp);
 
     GLCall(glDrawElements(GL_TRIANGLES, ib.GetCount(), GL_UNSIGNED_INT, nullptr));
 }
@@ -155,12 +149,12 @@ void Renderer::Clear()
     GLCall(glClear(GL_COLOR_BUFFER_BIT));
 }
 
-float Renderer::GetXCoordMax()
+float Renderer::GetXCoordMax() const
 {
     return SCREEN_X_COORDS;
 }
 
-float Renderer::GetYCoordMax()
+float Renderer::GetYCoordMax() const
 {
     return SCREEN_Y_COORDS;
 }

--- a/engine/renderer.cpp
+++ b/engine/renderer.cpp
@@ -24,8 +24,11 @@ namespace pong
 static constexpr float SCREEN_X_COORDS = 1280;
 static constexpr float SCREEN_Y_COORDS = 960;
 
-void Renderer::Init()
+void Renderer::Init(ComponentManager* componentManager)
 {
+    ASSERT(componentManager != nullptr);
+    mComponentManager = componentManager;
+
     if (glewInit() != GLEW_OK)
     {
         LogError("glewInit() failure");
@@ -90,7 +93,7 @@ void Renderer::DrawAll()
         Renderer::Draw(renderData, position);
     }
 
-    const std::vector<UIComponent*>& uiComponents = Pong::GetInstance().GetComponentManager().GetUIComponents();
+    const std::vector<UIComponent*>& uiComponents = mComponentManager->GetUIComponents();
     for (const auto& uiComponent : uiComponents)
     {
         const Transform* transform = uiComponent->GetBaseComponent()->GetComponent<Transform>();

--- a/engine/renderer.h
+++ b/engine/renderer.h
@@ -16,32 +16,26 @@ namespace pong
 class Renderer
 {
 public:
-    static Renderer& GetInstance();
-
-    static void Init();
-    static void Cleanup();
-    static void DrawAll();
-    static void Draw(const std::vector<OffsetGraphic>& graphics, const glm::vec3& position);
-    static void Draw(const Graphic& graphic, const glm::vec3& position);
-    static void Draw(const RenderData& renderData, const glm::vec3& position);
-    static void Draw(const VertexArray& va, const IndexBuffer& ib,
-                     const Texture& texture, const GLRGBAColor& color,
-                     const glm::vec3& position);
-    static void Clear();
-
-    // Returns the maximum X coordinate of the viewable screen (minimum in opposite direction)
-    static float GetXCoordMax();
-    // Returns the maximum Y coordinate of the viewable screen (minimum in opposite direction)
-    static float GetYCoordMax();
-
-private:
     Renderer() = default;
-    Renderer(const Renderer&) = delete;
-    Renderer& operator=(const Renderer&) = delete;
-    Renderer(Renderer&&) = delete;
-    Renderer& operator=(Renderer&&) = delete;
     ~Renderer() = default;
 
+    void Init();
+    void Cleanup();
+    void DrawAll();
+    void Draw(const std::vector<OffsetGraphic>& graphics, const glm::vec3& position);
+    void Draw(const Graphic& graphic, const glm::vec3& position);
+    void Draw(const RenderData& renderData, const glm::vec3& position);
+    void Draw(const VertexArray& va, const IndexBuffer& ib,
+                     const Texture& texture, const GLRGBAColor& color,
+                     const glm::vec3& position);
+    void Clear();
+
+    // Returns the maximum X coordinate of the viewable screen (minimum in opposite direction)
+    float GetXCoordMax() const;
+    // Returns the maximum Y coordinate of the viewable screen (minimum in opposite direction)
+    float GetYCoordMax() const;
+
+private:
     std::unique_ptr<Shader>mShader { nullptr };
 };
 

--- a/engine/renderer.h
+++ b/engine/renderer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "componentmanager.h"
 #include "graphic.h"
 #include "indexbuffer.h"
 #include "mesh.h"
@@ -19,7 +20,7 @@ public:
     Renderer() = default;
     ~Renderer() = default;
 
-    void Init();
+    void Init(ComponentManager* componentManager);
     void Cleanup();
     void DrawAll();
     void Draw(const std::vector<OffsetGraphic>& graphics, const glm::vec3& position);
@@ -36,7 +37,8 @@ public:
     float GetYCoordMax() const;
 
 private:
-    std::unique_ptr<Shader>mShader { nullptr };
+    ComponentManager* mComponentManager { nullptr };
+    std::unique_ptr<Shader> mShader { nullptr };
 };
 
 } // namespace pong

--- a/engine/scene/componentdeserializer.cpp
+++ b/engine/scene/componentdeserializer.cpp
@@ -121,11 +121,11 @@ void ComponentDeserializer::VisitComponent(Text* component)
     if (mCurrentJson.contains("font"))
     {
         const std::string fontName = mCurrentJson["font"];
-        font = game::GetPongInstance()->GetFontBank().GetFont(fontName);
+        font = globals::game::GetPongInstance()->GetFontBank().GetFont(fontName);
     }
     else
     {
-        font = game::GetPongInstance()->GetFontBank().GetDefaultFont();
+        font = globals::game::GetPongInstance()->GetFontBank().GetDefaultFont();
     }
     ASSERT(font != nullptr);
     component->mFont = font;

--- a/engine/scene/componentdeserializer.cpp
+++ b/engine/scene/componentdeserializer.cpp
@@ -121,11 +121,11 @@ void ComponentDeserializer::VisitComponent(Text* component)
     if (mCurrentJson.contains("font"))
     {
         const std::string fontName = mCurrentJson["font"];
-        font = Pong::GetInstance().GetFontBank().GetFont(fontName);
+        font = game::GetPongInstance()->GetFontBank().GetFont(fontName);
     }
     else
     {
-        font = Pong::GetInstance().GetFontBank().GetDefaultFont();
+        font = game::GetPongInstance()->GetFontBank().GetDefaultFont();
     }
     ASSERT(font != nullptr);
     component->mFont = font;

--- a/engine/timer.cpp
+++ b/engine/timer.cpp
@@ -60,9 +60,19 @@ namespace pong::timer
 
 Timer* gTimer { nullptr };
 
+Timer* GetTimerInstance()
+{
+    return gTimer;
+}
+
+void SetTimerInstance(Timer* timer)
+{
+    gTimer = timer;
+}
+
 void SetTimeout(int gameObjectId, std::chrono::duration<double> timeout, std::function<void()> callback)
 {
-    gTimer->AddTimer(gameObjectId, timeout, callback);
+    GetTimerInstance()->AddTimer(gameObjectId, timeout, callback);
 }
 
 } // namespace pong::timer

--- a/engine/timer.cpp
+++ b/engine/timer.cpp
@@ -1,5 +1,7 @@
 #include "timer.h"
 
+#include "utils.h"
+
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
@@ -62,6 +64,7 @@ Timer* gTimer { nullptr };
 
 Timer* GetTimerInstance()
 {
+    ASSERT(gTimer != nullptr);
     return gTimer;
 }
 

--- a/engine/timer.cpp
+++ b/engine/timer.cpp
@@ -54,3 +54,15 @@ void Timer::Reset()
 }
 
 } // namespace pong
+
+namespace pong::timer
+{
+
+Timer* gTimer { nullptr };
+
+void SetTimeout(int gameObjectId, std::chrono::duration<double> timeout, std::function<void()> callback)
+{
+    gTimer->AddTimer(gameObjectId, timeout, callback);
+}
+
+} // namespace pong::timer

--- a/engine/timer.h
+++ b/engine/timer.h
@@ -41,3 +41,12 @@ private:
 };
 
 } // namespace pong
+
+namespace pong::timer
+{
+
+extern Timer* gTimer;
+
+void SetTimeout(int gameObjectId, std::chrono::duration<double> timeout, std::function<void()> callback);
+
+} // namespace pong::timer

--- a/engine/timer.h
+++ b/engine/timer.h
@@ -47,6 +47,9 @@ namespace pong::timer
 
 extern Timer* gTimer;
 
+Timer* GetTimerInstance();
+void SetTimerInstance(Timer* timer);
+
 void SetTimeout(int gameObjectId, std::chrono::duration<double> timeout, std::function<void()> callback);
 
 } // namespace pong::timer

--- a/engine/uieventmanager.cpp
+++ b/engine/uieventmanager.cpp
@@ -40,7 +40,7 @@ void UIEventManager::ProcessEvents()
 void UIEventManager::Process(Button& button) const
 {
     const bool inBounds = CheckMouseInComponentBounds(button, button.GetBounds());
-    const InputState mouseButtonState = Input::GetMouseButtonState(GLFW_MOUSE_BUTTON_LEFT);
+    const InputState mouseButtonState = input::GetMouseButtonState(GLFW_MOUSE_BUTTON_LEFT);
 
     if (inBounds)
     {
@@ -67,7 +67,7 @@ void UIEventManager::Process(Button& button) const
 void UIEventManager::Process(CheckBox& checkBox) const
 {
     const bool inBounds = CheckMouseInComponentBounds(checkBox, checkBox.GetBounds());
-    const InputState mouseButtonState = Input::GetMouseButtonState(GLFW_MOUSE_BUTTON_LEFT);
+    const InputState mouseButtonState = input::GetMouseButtonState(GLFW_MOUSE_BUTTON_LEFT);
 
     if (inBounds && mouseButtonState == InputState::Pressed)
     {
@@ -78,11 +78,11 @@ void UIEventManager::Process(CheckBox& checkBox) const
 void UIEventManager::Process(Slider& slider) const
 {
     const bool inBounds = CheckMouseInComponentBounds(slider, slider.GetBounds());
-    const bool mousePressed = Input::CheckMouseButtonDown(GLFW_MOUSE_BUTTON_LEFT);
+    const bool mousePressed = input::CheckMouseButtonDown(GLFW_MOUSE_BUTTON_LEFT);
 
     if ((inBounds && mousePressed) || (mousePressed && slider.WasPressed()))
     {
-        slider.OnMouseDown(Input::GetMousePosition());
+        slider.OnMouseDown(input::GetMousePosition());
     }
     else if (!mousePressed && slider.WasPressed())
     {
@@ -108,7 +108,7 @@ bool UIEventManager::CheckMouseInComponentBounds(BaseComponent& component, Recta
 
 bool UIEventManager::CheckMouseInBounds(const RectangleBounds& bounds) const
 {
-    const glm::vec3 mousePosition = Input::GetMousePosition();
+    const glm::vec3 mousePosition = input::GetMousePosition();
     return bounds.CheckPointInBounds(mousePosition);
 }
 

--- a/engine/uieventmanager.cpp
+++ b/engine/uieventmanager.cpp
@@ -40,7 +40,7 @@ void UIEventManager::ProcessEvents()
 void UIEventManager::Process(Button& button) const
 {
     const bool inBounds = CheckMouseInComponentBounds(button, button.GetBounds());
-    const InputState mouseButtonState = input::GetMouseButtonState(GLFW_MOUSE_BUTTON_LEFT);
+    const InputState mouseButtonState = globals::input::GetMouseButtonState(GLFW_MOUSE_BUTTON_LEFT);
 
     if (inBounds)
     {
@@ -67,7 +67,7 @@ void UIEventManager::Process(Button& button) const
 void UIEventManager::Process(CheckBox& checkBox) const
 {
     const bool inBounds = CheckMouseInComponentBounds(checkBox, checkBox.GetBounds());
-    const InputState mouseButtonState = input::GetMouseButtonState(GLFW_MOUSE_BUTTON_LEFT);
+    const InputState mouseButtonState = globals::input::GetMouseButtonState(GLFW_MOUSE_BUTTON_LEFT);
 
     if (inBounds && mouseButtonState == InputState::Pressed)
     {
@@ -78,11 +78,11 @@ void UIEventManager::Process(CheckBox& checkBox) const
 void UIEventManager::Process(Slider& slider) const
 {
     const bool inBounds = CheckMouseInComponentBounds(slider, slider.GetBounds());
-    const bool mousePressed = input::CheckMouseButtonDown(GLFW_MOUSE_BUTTON_LEFT);
+    const bool mousePressed = globals::input::CheckMouseButtonDown(GLFW_MOUSE_BUTTON_LEFT);
 
     if ((inBounds && mousePressed) || (mousePressed && slider.WasPressed()))
     {
-        slider.OnMouseDown(input::GetMousePosition());
+        slider.OnMouseDown(globals::input::GetMousePosition());
     }
     else if (!mousePressed && slider.WasPressed())
     {
@@ -108,7 +108,7 @@ bool UIEventManager::CheckMouseInComponentBounds(BaseComponent& component, Recta
 
 bool UIEventManager::CheckMouseInBounds(const RectangleBounds& bounds) const
 {
-    const glm::vec3 mousePosition = input::GetMousePosition();
+    const glm::vec3 mousePosition = globals::input::GetMousePosition();
     return bounds.CheckPointInBounds(mousePosition);
 }
 

--- a/gameobjects/CMakeLists.txt
+++ b/gameobjects/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(gameobjects
         render
         engine
         components
+        audio
 )
 
 target_include_directories(gameobjects

--- a/gameobjects/ball.cpp
+++ b/gameobjects/ball.cpp
@@ -1,5 +1,6 @@
 #include "ball.h"
 
+#include "audiomixer.h"
 #include "config.h"
 #include "logger.h"
 #include "opponent.h"
@@ -40,16 +41,16 @@ void Ball::OnCollisionStart(GameObject& other)
 {
     if (other.GetInstanceName().find("ScoreArea") != std::string::npos)
     {
-        PlaySound(mScoreSound, mTransform->mPosition);
+        audio::PlaySound(mScoreSound, mTransform->mPosition);
 
-        SetTimeout(BALL_RESET_WAIT_S, [this] ()
+        timer::SetTimeout(GetGameObjectId(), BALL_RESET_WAIT_S, [this] ()
         {
             this->ResetBall();
         });
     }
     else if (other.GetInstanceName() == "Player" || other.GetInstanceName() == "Opponent")
     {
-        PlaySound(mPaddleBounceSound, mTransform->mPosition);
+        audio::PlaySound(mPaddleBounceSound, mTransform->mPosition);
 
         mSpeed += BALL_SPEED_BOUNCE_INCREMENT;
 
@@ -79,7 +80,7 @@ void Ball::OnCollisionStart(GameObject& other)
     }
     else
     {
-        PlaySound(mWallBounceSound, mTransform->mPosition);
+        audio::PlaySound(mWallBounceSound, mTransform->mPosition);
 
         mSpeed += BALL_SPEED_BOUNCE_INCREMENT;
         mVelocity = glm::normalize(glm::vec3(mVelocity.x, -mVelocity.y, 0.0f)) * mSpeed;

--- a/gameobjects/ball.cpp
+++ b/gameobjects/ball.cpp
@@ -41,7 +41,7 @@ void Ball::OnCollisionStart(GameObject& other)
 {
     if (other.GetInstanceName().find("ScoreArea") != std::string::npos)
     {
-        audio::PlaySound(mScoreSound, mTransform->mPosition);
+        globals::audio::PlaySound(mScoreSound, mTransform->mPosition);
 
         timer::SetTimeout(GetGameObjectId(), BALL_RESET_WAIT_S, [this] ()
         {
@@ -50,7 +50,7 @@ void Ball::OnCollisionStart(GameObject& other)
     }
     else if (other.GetInstanceName() == "Player" || other.GetInstanceName() == "Opponent")
     {
-        audio::PlaySound(mPaddleBounceSound, mTransform->mPosition);
+        globals::audio::PlaySound(mPaddleBounceSound, mTransform->mPosition);
 
         mSpeed += BALL_SPEED_BOUNCE_INCREMENT;
 
@@ -80,7 +80,7 @@ void Ball::OnCollisionStart(GameObject& other)
     }
     else
     {
-        audio::PlaySound(mWallBounceSound, mTransform->mPosition);
+        globals::audio::PlaySound(mWallBounceSound, mTransform->mPosition);
 
         mSpeed += BALL_SPEED_BOUNCE_INCREMENT;
         mVelocity = glm::normalize(glm::vec3(mVelocity.x, -mVelocity.y, 0.0f)) * mSpeed;

--- a/gameobjects/gameobject.h
+++ b/gameobjects/gameobject.h
@@ -53,7 +53,7 @@ public:
 
         const int componentId = GetComponentTypeId<T>();
         mComponents.insert(std::make_pair(componentId, componentPtr));
-        Pong::GetInstance().GetComponentManager().AddComponent<T>(std::move(component));
+        game::GetPongInstance()->GetComponentManager().AddComponent<T>(std::move(component));
 
         return componentPtr;
     }

--- a/gameobjects/gameobject.h
+++ b/gameobjects/gameobject.h
@@ -53,7 +53,7 @@ public:
 
         const int componentId = GetComponentTypeId<T>();
         mComponents.insert(std::make_pair(componentId, componentPtr));
-        game::GetPongInstance()->GetComponentManager().AddComponent<T>(std::move(component));
+        globals::game::GetPongInstance()->GetComponentManager().AddComponent<T>(std::move(component));
 
         return componentPtr;
     }

--- a/gameobjects/gameoverscreencontroller.cpp
+++ b/gameobjects/gameoverscreencontroller.cpp
@@ -10,12 +10,12 @@ namespace pong
 
 void GameOverScreenController::OnStart()
 {
-    const ScoreController* score = Pong::FindComponentOfType<ScoreController>();
+    const ScoreController* score = game::FindComponentOfType<ScoreController>();
     ASSERT(score != nullptr);
     score->GetGameObject()->SetDestroyOnLoad(true);
     mPlayerWon = score->GetPlayerScore() > score->GetOpponentScore();
 
-    mResultText = Pong::FindGameObjectByName("ResultText")->GetComponent<Text>();
+    mResultText = game::FindGameObjectByName("ResultText")->GetComponent<Text>();
     if (mPlayerWon)
     {
         mResultText->SetText("You won!");
@@ -25,19 +25,19 @@ void GameOverScreenController::OnStart()
         mResultText->SetText("You lost!");
     }
 
-    mPlayAgainButton = Pong::FindGameObjectByName("PlayButton")->GetComponent<Button>();
+    mPlayAgainButton = game::FindGameObjectByName("PlayButton")->GetComponent<Button>();
     mPlayAgainButton->AddListener(ButtonEvent::Pressed, []() {
-        Pong::LoadSceneNext("Game");
+        game::LoadSceneNext("Game");
     });
     SetupButton(mPlayAgainButton, mPlayAgainButton->GetComponent<Text>());
 
-    mTitleScreenButton = Pong::FindGameObjectByName("TitleButton")->GetComponent<Button>();
+    mTitleScreenButton = game::FindGameObjectByName("TitleButton")->GetComponent<Button>();
     mTitleScreenButton->AddListener(ButtonEvent::Pressed, []() {
-        Pong::LoadSceneNext("Title");
+        game::LoadSceneNext("Title");
     });
     SetupButton(mTitleScreenButton, mTitleScreenButton->GetComponent<Text>());
 
-    mQuitButton = Pong::FindGameObjectByName("QuitButton")->GetComponent<Button>();
+    mQuitButton = game::FindGameObjectByName("QuitButton")->GetComponent<Button>();
     mQuitButton->AddListener(ButtonEvent::Pressed, []() {
         engine::QuitApplication();
     });

--- a/gameobjects/gameoverscreencontroller.cpp
+++ b/gameobjects/gameoverscreencontroller.cpp
@@ -10,12 +10,12 @@ namespace pong
 
 void GameOverScreenController::OnStart()
 {
-    const ScoreController* score = game::FindComponentOfType<ScoreController>();
+    const ScoreController* score = globals::game::FindComponentOfType<ScoreController>();
     ASSERT(score != nullptr);
     score->GetGameObject()->SetDestroyOnLoad(true);
     mPlayerWon = score->GetPlayerScore() > score->GetOpponentScore();
 
-    mResultText = game::FindGameObjectByName("ResultText")->GetComponent<Text>();
+    mResultText = globals::game::FindGameObjectByName("ResultText")->GetComponent<Text>();
     if (mPlayerWon)
     {
         mResultText->SetText("You won!");
@@ -25,21 +25,21 @@ void GameOverScreenController::OnStart()
         mResultText->SetText("You lost!");
     }
 
-    mPlayAgainButton = game::FindGameObjectByName("PlayButton")->GetComponent<Button>();
+    mPlayAgainButton = globals::game::FindGameObjectByName("PlayButton")->GetComponent<Button>();
     mPlayAgainButton->AddListener(ButtonEvent::Pressed, []() {
-        game::LoadSceneNext("Game");
+        globals::game::LoadSceneNext("Game");
     });
     SetupButton(mPlayAgainButton, mPlayAgainButton->GetComponent<Text>());
 
-    mTitleScreenButton = game::FindGameObjectByName("TitleButton")->GetComponent<Button>();
+    mTitleScreenButton = globals::game::FindGameObjectByName("TitleButton")->GetComponent<Button>();
     mTitleScreenButton->AddListener(ButtonEvent::Pressed, []() {
-        game::LoadSceneNext("Title");
+        globals::game::LoadSceneNext("Title");
     });
     SetupButton(mTitleScreenButton, mTitleScreenButton->GetComponent<Text>());
 
-    mQuitButton = game::FindGameObjectByName("QuitButton")->GetComponent<Button>();
+    mQuitButton = globals::game::FindGameObjectByName("QuitButton")->GetComponent<Button>();
     mQuitButton->AddListener(ButtonEvent::Pressed, []() {
-        engine::QuitApplication();
+        globals::engine::QuitApplication();
     });
     SetupButton(mQuitButton, mQuitButton->GetComponent<Text>());
 }

--- a/gameobjects/gameoverscreencontroller.cpp
+++ b/gameobjects/gameoverscreencontroller.cpp
@@ -39,7 +39,7 @@ void GameOverScreenController::OnStart()
 
     mQuitButton = Pong::FindGameObjectByName("QuitButton")->GetComponent<Button>();
     mQuitButton->AddListener(ButtonEvent::Pressed, []() {
-        Engine::QuitApplication();
+        engine::QuitApplication();
     });
     SetupButton(mQuitButton, mQuitButton->GetComponent<Text>());
 }

--- a/gameobjects/opponent.cpp
+++ b/gameobjects/opponent.cpp
@@ -22,8 +22,8 @@ void Opponent::OnStart()
     mCollider = GetComponent<ColliderBox>();
     mTargetPosition = mTransform->mPosition;
 
-    GameObject* topWall = game::FindGameObjectByName("TopWall");
-    GameObject* bottomWall = game::FindGameObjectByName("BottomWall");
+    GameObject* topWall = globals::game::FindGameObjectByName("TopWall");
+    GameObject* bottomWall = globals::game::FindGameObjectByName("BottomWall");
 
     ASSERT(bottomWall != nullptr && topWall != nullptr);
 

--- a/gameobjects/opponent.cpp
+++ b/gameobjects/opponent.cpp
@@ -22,8 +22,8 @@ void Opponent::OnStart()
     mCollider = GetComponent<ColliderBox>();
     mTargetPosition = mTransform->mPosition;
 
-    GameObject* topWall = Pong::FindGameObjectByName("TopWall");
-    GameObject* bottomWall = Pong::FindGameObjectByName("BottomWall");
+    GameObject* topWall = game::FindGameObjectByName("TopWall");
+    GameObject* bottomWall = game::FindGameObjectByName("BottomWall");
 
     ASSERT(bottomWall != nullptr && topWall != nullptr);
 

--- a/gameobjects/opponent.cpp
+++ b/gameobjects/opponent.cpp
@@ -159,7 +159,8 @@ void Opponent::OnBallVelocityChange(const glm::vec3& velocity)
 
     if (mChasingBall)
     {
-        SetTimeout(std::chrono::milliseconds(Random::ValueInRange(mDecisionTimeLowerBounmMs, mDecisionTimeUpperBoundMs)), [this] ()
+        const int decisionTime = Random::ValueInRange(mDecisionTimeLowerBounmMs, mDecisionTimeUpperBoundMs);
+        timer::SetTimeout(GetGameObjectId(), std::chrono::milliseconds(decisionTime), [this] ()
         {
             this->PredictBallPostion();
         });

--- a/gameobjects/opponent.cpp
+++ b/gameobjects/opponent.cpp
@@ -159,8 +159,8 @@ void Opponent::OnBallVelocityChange(const glm::vec3& velocity)
 
     if (mChasingBall)
     {
-        const int decisionTime = Random::ValueInRange(mDecisionTimeLowerBoundMs, mDecisionTimeUpperBoundMs);
-        timer::SetTimeout(GetGameObjectId(), std::chrono::milliseconds(decisionTime), [this] ()
+        const int decisionTimeMs = Random::ValueInRange(mDecisionTimeLowerBoundMs, mDecisionTimeUpperBoundMs);
+        timer::SetTimeout(GetGameObjectId(), std::chrono::milliseconds(decisionTimeMs), [this] ()
         {
             this->PredictBallPostion();
         });

--- a/gameobjects/player.cpp
+++ b/gameobjects/player.cpp
@@ -21,11 +21,11 @@ void Player::OnUpdate()
 {
     mVelocity = glm::vec3(0.0f);
 
-    if (Input::CheckKeyDown(GLFW_KEY_W))
+    if (input::CheckKeyDown(GLFW_KEY_W))
     {
         mVelocity = glm::vec3(0.0f, mSpeed, 0.0f);
     }
-    else if (Input::CheckKeyDown(GLFW_KEY_S))
+    else if (input::CheckKeyDown(GLFW_KEY_S))
     {
         mVelocity = glm::vec3(0.0f, -mSpeed, 0.0f);
     }

--- a/gameobjects/player.cpp
+++ b/gameobjects/player.cpp
@@ -21,11 +21,11 @@ void Player::OnUpdate()
 {
     mVelocity = glm::vec3(0.0f);
 
-    if (input::CheckKeyDown(GLFW_KEY_W))
+    if (globals::input::CheckKeyDown(GLFW_KEY_W))
     {
         mVelocity = glm::vec3(0.0f, mSpeed, 0.0f);
     }
-    else if (input::CheckKeyDown(GLFW_KEY_S))
+    else if (globals::input::CheckKeyDown(GLFW_KEY_S))
     {
         mVelocity = glm::vec3(0.0f, -mSpeed, 0.0f);
     }

--- a/gameobjects/scorearea.cpp
+++ b/gameobjects/scorearea.cpp
@@ -16,7 +16,7 @@ ScoreArea::ScoreArea(bool playerSide) :
 
 void ScoreArea::OnStart()
 {
-    mScoreController = game::FindComponentOfType<ScoreController>();
+    mScoreController = globals::game::FindComponentOfType<ScoreController>();
     if (mScoreController == nullptr)
     {
         LogError("ScoreController instance not found!");

--- a/gameobjects/scorearea.cpp
+++ b/gameobjects/scorearea.cpp
@@ -16,7 +16,7 @@ ScoreArea::ScoreArea(bool playerSide) :
 
 void ScoreArea::OnStart()
 {
-    mScoreController = Pong::FindComponentOfType<ScoreController>();
+    mScoreController = game::FindComponentOfType<ScoreController>();
     if (mScoreController == nullptr)
     {
         LogError("ScoreController instance not found!");

--- a/gameobjects/scorecontroller.cpp
+++ b/gameobjects/scorecontroller.cpp
@@ -40,7 +40,7 @@ void ScoreController::CheckForWin()
 {
     if (mPlayerScore >= mWinningScore || mOpponentScore >= mWinningScore)
     {
-        game::LoadSceneNext("GameOver");
+        globals::game::LoadSceneNext("GameOver");
     }
 }
 

--- a/gameobjects/scorecontroller.cpp
+++ b/gameobjects/scorecontroller.cpp
@@ -40,7 +40,7 @@ void ScoreController::CheckForWin()
 {
     if (mPlayerScore >= mWinningScore || mOpponentScore >= mWinningScore)
     {
-        Pong::LoadSceneNext("GameOver");
+        game::LoadSceneNext("GameOver");
     }
 }
 

--- a/gameobjects/settingsscreencontroller.cpp
+++ b/gameobjects/settingsscreencontroller.cpp
@@ -18,13 +18,13 @@ void SettingsScreenController::OnStart()
     });
     SetupButton(mBackButton, mBackButton->GetComponent<Text>());
 
-    const int targetFPS = Engine::GetTargetFPS();
+    const int targetFPS = engine::GetTargetFPS();
     mTargetFPSText = Pong::FindGameObjectByName("TargetFPSText")->GetComponent<Text>();
     mTargetFPSText->SetText("Target FPS: " + std::to_string(targetFPS));
     mTargetFPSSlider = Pong::FindGameObjectByName("TargetFPSSlider")->GetComponent<Slider>();
     mTargetFPSSlider->SetValue(static_cast<float>(targetFPS));
     mTargetFPSSlider->AddValueChangeListener([this] (float newValue) {
-        Engine::SetTargetFPS(static_cast<int>(newValue));
+        engine::SetTargetFPS(static_cast<int>(newValue));
         this->mTargetFPSText->SetText("Target FPS: " + std::to_string(static_cast<int>(newValue)));
     });
 

--- a/gameobjects/settingsscreencontroller.cpp
+++ b/gameobjects/settingsscreencontroller.cpp
@@ -12,36 +12,36 @@ namespace pong
 
 void SettingsScreenController::OnStart()
 {
-    mBackButton = Pong::FindGameObjectByName("BackButton")->GetComponent<Button>();
+    mBackButton = game::FindGameObjectByName("BackButton")->GetComponent<Button>();
     mBackButton->AddListener(ButtonEvent::Pressed, []() {
-        Pong::LoadSceneNext("Title");
+        game::LoadSceneNext("Title");
     });
     SetupButton(mBackButton, mBackButton->GetComponent<Text>());
 
     const int targetFPS = engine::GetTargetFPS();
-    mTargetFPSText = Pong::FindGameObjectByName("TargetFPSText")->GetComponent<Text>();
+    mTargetFPSText = game::FindGameObjectByName("TargetFPSText")->GetComponent<Text>();
     mTargetFPSText->SetText("Target FPS: " + std::to_string(targetFPS));
-    mTargetFPSSlider = Pong::FindGameObjectByName("TargetFPSSlider")->GetComponent<Slider>();
+    mTargetFPSSlider = game::FindGameObjectByName("TargetFPSSlider")->GetComponent<Slider>();
     mTargetFPSSlider->SetValue(static_cast<float>(targetFPS));
     mTargetFPSSlider->AddValueChangeListener([this] (float newValue) {
         engine::SetTargetFPS(static_cast<int>(newValue));
         this->mTargetFPSText->SetText("Target FPS: " + std::to_string(static_cast<int>(newValue)));
     });
 
-    mVSync = Pong::FindGameObjectByName("VSyncEnable")->GetComponent<CheckBox>();
+    mVSync = game::FindGameObjectByName("VSyncEnable")->GetComponent<CheckBox>();
     mVSync->SetValue(application::IsVSyncActive());
     mVSync->AddValueChangeListener([] (bool value) {
         application::SetVSync(value);
     });
 
-    mSpatialAudio = Pong::FindGameObjectByName("SpatialAudioEnable")->GetComponent<CheckBox>();
+    mSpatialAudio = game::FindGameObjectByName("SpatialAudioEnable")->GetComponent<CheckBox>();
     mSpatialAudio->AddValueChangeListener([] (bool value) {
         audio::SetSpatialAudioEnabled(value);
     });
 
     for (int i = 0; i < 4; i++)
     {
-        mDifficultyCheckBoxes[i] = Pong::FindGameObjectByName("DifficultyEnable" + std::to_string(i))->GetComponent<CheckBox>();
+        mDifficultyCheckBoxes[i] = game::FindGameObjectByName("DifficultyEnable" + std::to_string(i))->GetComponent<CheckBox>();
         mDifficultyCheckBoxes[i]->SetValue(Difficulty::GetLevel() == static_cast<Difficulty::Level>(i));
         mDifficultyCheckBoxes[i]->AddValueChangeListener([this, i] (bool value) {
             if (value)
@@ -58,10 +58,10 @@ void SettingsScreenController::OnStart()
         });
     }
 
-    mVolumeText = Pong::FindGameObjectByName("VolumeText")->GetComponent<Text>();
+    mVolumeText = game::FindGameObjectByName("VolumeText")->GetComponent<Text>();
     const float volume = audio::GetVolume();
     mVolumeText->SetText("Volume: " + std::to_string(static_cast<int>(volume * 100.0f)));
-    mVolumeSlider = Pong::FindGameObjectByName("VolumeSlider")->GetComponent<Slider>();
+    mVolumeSlider = game::FindGameObjectByName("VolumeSlider")->GetComponent<Slider>();
     mVolumeSlider->SetValue(volume);
     mVolumeSlider->AddValueChangeListener([this] (float newValue) {
         audio::SetVolume(newValue);

--- a/gameobjects/settingsscreencontroller.cpp
+++ b/gameobjects/settingsscreencontroller.cpp
@@ -36,7 +36,7 @@ void SettingsScreenController::OnStart()
 
     mSpatialAudio = Pong::FindGameObjectByName("SpatialAudioEnable")->GetComponent<CheckBox>();
     mSpatialAudio->AddValueChangeListener([] (bool value) {
-        Pong::GetInstance().GetAudioMixer().SetSpatialAudioEnabled(value);
+        audio::SetSpatialAudioEnabled(value);
     });
 
     for (int i = 0; i < 4; i++)
@@ -59,12 +59,12 @@ void SettingsScreenController::OnStart()
     }
 
     mVolumeText = Pong::FindGameObjectByName("VolumeText")->GetComponent<Text>();
-    const float volume = Pong::GetInstance().GetAudioMixer().GetVolume();
+    const float volume = audio::GetVolume();
     mVolumeText->SetText("Volume: " + std::to_string(static_cast<int>(volume * 100.0f)));
     mVolumeSlider = Pong::FindGameObjectByName("VolumeSlider")->GetComponent<Slider>();
     mVolumeSlider->SetValue(volume);
     mVolumeSlider->AddValueChangeListener([this] (float newValue) {
-        Pong::GetInstance().GetAudioMixer().SetVolume(newValue);
+        audio::SetVolume(newValue);
         this->mVolumeText->SetText("Volume: " + std::to_string(static_cast<int>(roundf(newValue * 100.0f))));
     });
 }

--- a/gameobjects/settingsscreencontroller.cpp
+++ b/gameobjects/settingsscreencontroller.cpp
@@ -12,36 +12,36 @@ namespace pong
 
 void SettingsScreenController::OnStart()
 {
-    mBackButton = game::FindGameObjectByName("BackButton")->GetComponent<Button>();
+    mBackButton = globals::game::FindGameObjectByName("BackButton")->GetComponent<Button>();
     mBackButton->AddListener(ButtonEvent::Pressed, []() {
-        game::LoadSceneNext("Title");
+        globals::game::LoadSceneNext("Title");
     });
     SetupButton(mBackButton, mBackButton->GetComponent<Text>());
 
-    const int targetFPS = engine::GetTargetFPS();
-    mTargetFPSText = game::FindGameObjectByName("TargetFPSText")->GetComponent<Text>();
+    const int targetFPS = globals::engine::GetTargetFPS();
+    mTargetFPSText = globals::game::FindGameObjectByName("TargetFPSText")->GetComponent<Text>();
     mTargetFPSText->SetText("Target FPS: " + std::to_string(targetFPS));
-    mTargetFPSSlider = game::FindGameObjectByName("TargetFPSSlider")->GetComponent<Slider>();
+    mTargetFPSSlider = globals::game::FindGameObjectByName("TargetFPSSlider")->GetComponent<Slider>();
     mTargetFPSSlider->SetValue(static_cast<float>(targetFPS));
     mTargetFPSSlider->AddValueChangeListener([this] (float newValue) {
-        engine::SetTargetFPS(static_cast<int>(newValue));
+        globals::engine::SetTargetFPS(static_cast<int>(newValue));
         this->mTargetFPSText->SetText("Target FPS: " + std::to_string(static_cast<int>(newValue)));
     });
 
-    mVSync = game::FindGameObjectByName("VSyncEnable")->GetComponent<CheckBox>();
-    mVSync->SetValue(application::IsVSyncActive());
+    mVSync = globals::game::FindGameObjectByName("VSyncEnable")->GetComponent<CheckBox>();
+    mVSync->SetValue(globals::application::IsVSyncActive());
     mVSync->AddValueChangeListener([] (bool value) {
-        application::SetVSync(value);
+        globals::application::SetVSync(value);
     });
 
-    mSpatialAudio = game::FindGameObjectByName("SpatialAudioEnable")->GetComponent<CheckBox>();
+    mSpatialAudio = globals::game::FindGameObjectByName("SpatialAudioEnable")->GetComponent<CheckBox>();
     mSpatialAudio->AddValueChangeListener([] (bool value) {
-        audio::SetSpatialAudioEnabled(value);
+        globals::audio::SetSpatialAudioEnabled(value);
     });
 
     for (int i = 0; i < 4; i++)
     {
-        mDifficultyCheckBoxes[i] = game::FindGameObjectByName("DifficultyEnable" + std::to_string(i))->GetComponent<CheckBox>();
+        mDifficultyCheckBoxes[i] = globals::game::FindGameObjectByName("DifficultyEnable" + std::to_string(i))->GetComponent<CheckBox>();
         mDifficultyCheckBoxes[i]->SetValue(Difficulty::GetLevel() == static_cast<Difficulty::Level>(i));
         mDifficultyCheckBoxes[i]->AddValueChangeListener([this, i] (bool value) {
             if (value)
@@ -58,13 +58,13 @@ void SettingsScreenController::OnStart()
         });
     }
 
-    mVolumeText = game::FindGameObjectByName("VolumeText")->GetComponent<Text>();
-    const float volume = audio::GetVolume();
+    mVolumeText = globals::game::FindGameObjectByName("VolumeText")->GetComponent<Text>();
+    const float volume = globals::audio::GetVolume();
     mVolumeText->SetText("Volume: " + std::to_string(static_cast<int>(volume * 100.0f)));
-    mVolumeSlider = game::FindGameObjectByName("VolumeSlider")->GetComponent<Slider>();
+    mVolumeSlider = globals::game::FindGameObjectByName("VolumeSlider")->GetComponent<Slider>();
     mVolumeSlider->SetValue(volume);
     mVolumeSlider->AddValueChangeListener([this] (float newValue) {
-        audio::SetVolume(newValue);
+        globals::audio::SetVolume(newValue);
         this->mVolumeText->SetText("Volume: " + std::to_string(static_cast<int>(roundf(newValue * 100.0f))));
     });
 }

--- a/gameobjects/settingsscreencontroller.cpp
+++ b/gameobjects/settingsscreencontroller.cpp
@@ -29,9 +29,9 @@ void SettingsScreenController::OnStart()
     });
 
     mVSync = Pong::FindGameObjectByName("VSyncEnable")->GetComponent<CheckBox>();
-    mVSync->SetValue(ApplicationWindow::IsVSyncActive());
+    mVSync->SetValue(application::IsVSyncActive());
     mVSync->AddValueChangeListener([] (bool value) {
-        ApplicationWindow::SetVSync(value);
+        application::SetVSync(value);
     });
 
     mSpatialAudio = Pong::FindGameObjectByName("SpatialAudioEnable")->GetComponent<CheckBox>();

--- a/gameobjects/titlescreencontroller.cpp
+++ b/gameobjects/titlescreencontroller.cpp
@@ -13,19 +13,19 @@ namespace pong
 
 void TitleScreenController::OnStart()
 {
-    mPlayButton = Pong::FindGameObjectByName("PlayButton")->GetComponent<Button>();
+    mPlayButton = game::FindGameObjectByName("PlayButton")->GetComponent<Button>();
     mPlayButton->AddListener(ButtonEvent::Pressed, []() {
-        Pong::LoadSceneNext("Game");
+        game::LoadSceneNext("Game");
     });
     SetupButton(mPlayButton, mPlayButton->GetComponent<Text>());
 
-    mSettingsButton = Pong::FindGameObjectByName("SettingsButton")->GetComponent<Button>();
+    mSettingsButton = game::FindGameObjectByName("SettingsButton")->GetComponent<Button>();
     mSettingsButton->AddListener(ButtonEvent::Pressed, []() {
-        Pong::LoadSceneNext("Settings");
+        game::LoadSceneNext("Settings");
     });
     SetupButton(mSettingsButton, mSettingsButton->GetComponent<Text>());
 
-    mQuitButton = Pong::FindGameObjectByName("QuitButton")->GetComponent<Button>();
+    mQuitButton = game::FindGameObjectByName("QuitButton")->GetComponent<Button>();
     mQuitButton->AddListener(ButtonEvent::Pressed, []() {
         engine::QuitApplication();
     });

--- a/gameobjects/titlescreencontroller.cpp
+++ b/gameobjects/titlescreencontroller.cpp
@@ -27,7 +27,7 @@ void TitleScreenController::OnStart()
 
     mQuitButton = Pong::FindGameObjectByName("QuitButton")->GetComponent<Button>();
     mQuitButton->AddListener(ButtonEvent::Pressed, []() {
-        Engine::QuitApplication();
+        engine::QuitApplication();
     });
     SetupButton(mQuitButton, mQuitButton->GetComponent<Text>());
 }

--- a/gameobjects/titlescreencontroller.cpp
+++ b/gameobjects/titlescreencontroller.cpp
@@ -13,21 +13,21 @@ namespace pong
 
 void TitleScreenController::OnStart()
 {
-    mPlayButton = game::FindGameObjectByName("PlayButton")->GetComponent<Button>();
+    mPlayButton = globals::game::FindGameObjectByName("PlayButton")->GetComponent<Button>();
     mPlayButton->AddListener(ButtonEvent::Pressed, []() {
-        game::LoadSceneNext("Game");
+        globals::game::LoadSceneNext("Game");
     });
     SetupButton(mPlayButton, mPlayButton->GetComponent<Text>());
 
-    mSettingsButton = game::FindGameObjectByName("SettingsButton")->GetComponent<Button>();
+    mSettingsButton = globals::game::FindGameObjectByName("SettingsButton")->GetComponent<Button>();
     mSettingsButton->AddListener(ButtonEvent::Pressed, []() {
-        game::LoadSceneNext("Settings");
+        globals::game::LoadSceneNext("Settings");
     });
     SetupButton(mSettingsButton, mSettingsButton->GetComponent<Text>());
 
-    mQuitButton = game::FindGameObjectByName("QuitButton")->GetComponent<Button>();
+    mQuitButton = globals::game::FindGameObjectByName("QuitButton")->GetComponent<Button>();
     mQuitButton->AddListener(ButtonEvent::Pressed, []() {
-        engine::QuitApplication();
+        globals::engine::QuitApplication();
     });
     SetupButton(mQuitButton, mQuitButton->GetComponent<Text>());
 }

--- a/main.cpp
+++ b/main.cpp
@@ -25,13 +25,13 @@ int main(int argc, char* argv[])
 
     Engine engine;
 
-    engine::gEngine = &engine;
+    engine::SetEngineInstance(&engine);
 
     engine.Init(argv[1]);
     engine.RunApplication();
     engine.Cleanup();
 
-    engine::gEngine = nullptr;
+    engine::SetEngineInstance(nullptr);
 
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -25,13 +25,13 @@ int main(int argc, char* argv[])
 
     Engine engine;
 
-    engine::SetEngineInstance(&engine);
+    globals::engine::SetEngineInstance(&engine);
 
     engine.Init(argv[1]);
     engine.RunApplication();
     engine.Cleanup();
 
-    engine::SetEngineInstance(nullptr);
+    globals::engine::SetEngineInstance(nullptr);
 
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -23,9 +23,15 @@ int main(int argc, char* argv[])
         return -1;
     }
 
-    Engine::GetInstance().Init(argv[1]);
-    Engine::GetInstance().RunApplication();
-    Engine::GetInstance().Cleanup();
+    Engine engine;
+
+    engine::gEngine = &engine;
+
+    engine.Init(argv[1]);
+    engine.RunApplication();
+    engine.Cleanup();
+
+    engine::gEngine = nullptr;
 
     return 0;
 }


### PR DESCRIPTION
A little hard to review since a lot of this is removing static keywords, removing GetInstance() calls, and removing static functions. The main idea is that in order to remove singletons, areas of the code that need to be accessed use free functions under a specific namespace. Ex to change the window's title from a user defined `Behavior`, `application::SetWindowTItle("My Game");` is used. 

Some of the singletons being removed:
Engine, Renderer, Input, Pong, ApplicationWindow

And importantly this uses depency injection to build the thing the game engine needs. The Engine class remains the top level class holding everything else `Renderer`, `ApplicationWindow`, `Input`, `Pong`, `Input` does depend on both the renderer and application window to properly use callbacks so they are passed into the constructor.
